### PR TITLE
Deserialization things

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "amino"
 version = "0.1.0"
-authors = ["zaki"]
+authors = ["zaki", "Ismail Khoffi <ismail@tendermint.com"]
 
 
 [dependencies]

--- a/amino-derive/Cargo.toml
+++ b/amino-derive/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "amino-derive"
 version = "0.1.0"
-authors = ["zaki"]
+authors = ["zaki", "Ismail Khoffi <ismail@tendermint.com"]
 
 [lib]
 proc-macro = true

--- a/amino-derive/src/lib.rs
+++ b/amino-derive/src/lib.rs
@@ -1,49 +1,51 @@
 extern crate itertools;
-extern crate proc_macro2;
 extern crate proc_macro;
-extern crate syn;
+extern crate proc_macro2;
 extern crate sha2;
+extern crate syn;
 
 #[macro_use]
 extern crate failure;
 #[macro_use]
 extern crate quote;
 
-use sha2::{Sha256, Digest};
 use failure::Error;
 use itertools::Itertools;
 use proc_macro::TokenStream;
+use sha2::{Digest, Sha256};
 use syn::punctuated::Punctuated;
 use syn::{
-    Data,
-    DataEnum,
-    DataStruct,
-    DeriveInput,
-    Expr,
-    Fields,
-    FieldsNamed,
-    FieldsUnnamed,
-    Ident,
+    Data, DataEnum, DataStruct, DeriveInput, Expr, Fields, FieldsNamed, FieldsUnnamed, Ident,
     Variant,
 };
 
-fn compute_disfix(identity: &str)->(Vec<u8>, Vec<u8>) {
+fn compute_disfix(identity: &str) -> (Vec<u8>, Vec<u8>) {
     let mut sh = Sha256::default();
     sh.input(identity.as_bytes());
-    let output =  sh.result();
-    let disamb_bytes = output.iter().filter(|&x| *x!= 0x00).cloned().take(3).collect();
-    let mut prefix_bytes:Vec<u8> = output.iter().filter(|&x| *x!= 0x00).skip(3).filter(|&x| *x!= 0x00).cloned().take(4).collect();
+    let output = sh.result();
+    let disamb_bytes = output
+        .iter()
+        .filter(|&x| *x != 0x00)
+        .cloned()
+        .take(3)
+        .collect();
+    let mut prefix_bytes: Vec<u8> = output
+        .iter()
+        .filter(|&x| *x != 0x00)
+        .skip(3)
+        .filter(|&x| *x != 0x00)
+        .cloned()
+        .take(4)
+        .collect();
     prefix_bytes[3] &= 0xF8;
-    return (disamb_bytes,prefix_bytes);
+    return (disamb_bytes, prefix_bytes);
 }
-
 
 fn try_message(input: TokenStream) -> Result<TokenStream, Error> {
     let input: DeriveInput = syn::parse(input)?;
-    let (dis_bytes,pre_bytes) = compute_disfix(input.ident.as_ref());
-    
-    if !input.generics.params.is_empty() ||
-       input.generics.where_clause.is_some() {
+    let (dis_bytes, pre_bytes) = compute_disfix(input.ident.as_ref());
+
+    if !input.generics.params.is_empty() || input.generics.where_clause.is_some() {
         bail!("Message may not be derived for generic type");
     }
 
@@ -54,21 +56,31 @@ fn try_message(input: TokenStream) -> Result<TokenStream, Error> {
     };
 
     let fields = match variant_data {
-        DataStruct { fields: Fields::Named(FieldsNamed { named: fields, .. }), .. } |
-        DataStruct { fields: Fields::Unnamed(FieldsUnnamed { unnamed: fields, .. }), ..} => {
-            fields.into_iter().collect()
-        },
-        DataStruct { fields: Fields::Unit, .. } => Vec::new(),
+        DataStruct {
+            fields: Fields::Named(FieldsNamed { named: fields, .. }),
+            ..
+        }
+        | DataStruct {
+            fields:
+                Fields::Unnamed(FieldsUnnamed {
+                    unnamed: fields, ..
+                }),
+            ..
+        } => fields.into_iter().collect(),
+        DataStruct {
+            fields: Fields::Unit,
+            ..
+        } => Vec::new(),
     };
-    print!("{} \n",input.ident);
-    print!("{:?} \n",fields);
+    print!("{} \n", input.ident);
+    print!("{:?} \n", fields);
 
     let module = Ident::from(format!("{}_WIRE", input.ident));
 
     let expanded = quote! {
         #[allow(non_snake_case, unused_attributes)]
         mod #module {
-            
+
         };
     };
     Ok(expanded.into())
@@ -78,4 +90,3 @@ fn try_message(input: TokenStream) -> Result<TokenStream, Error> {
 pub fn message(input: TokenStream) -> TokenStream {
     try_message(input).unwrap()
 }
-

--- a/src/encoding.rs
+++ b/src/encoding.rs
@@ -111,6 +111,25 @@ where
     }
 }
 
+pub fn consume_prefix<B>(buf: &mut B, registered_type: &str) -> Result<(), DecodeError>
+where
+    B: Buf,
+{
+    let (_, mut pre) = compute_disfix(registered_type);
+
+    pre[3] |= typ3_to_byte(Typ3Byte::Typ3_Struct);
+    let mut actual_prefix = vec![0u8; pre.len()];
+    buf.copy_to_slice(actual_prefix.as_mut_slice());
+    if actual_prefix != pre {
+        Err(DecodeError::new(format!(
+            "invalid prefix got: {:?}, want: {:?}",
+            actual_prefix, pre
+        )))
+    } else {
+        Ok(())
+    }
+}
+
 pub fn compute_disfix(identity: &str) -> (Vec<u8>, Vec<u8>) {
     let mut sh = Sha256::default();
     sh.input(identity.as_bytes());


### PR DESCRIPTION
- add to public API: `consume_length` and `consume_prefix` to have less code duplication in kms
- remove explicit `return` statements: src/encoding.rs
- rustfmt on amino-derive/src/lib.rs
- authors