### PR TITLE
Use renamed crate name consitently

### DIFF
--- a/benchmarks/src/lib.rs
+++ b/benchmarks/src/lib.rs
@@ -1,7 +1,7 @@
 #![feature(test)]
 
 extern crate bytes;
-extern crate prost;
+extern crate prost_amino as prost;
 extern crate test;
 
 #[macro_use]

--- a/conformance/src/main.rs
+++ b/conformance/src/main.rs
@@ -1,6 +1,6 @@
 extern crate bytes;
 extern crate env_logger;
-extern crate prost;
+extern crate prost_amino as prost;
 extern crate tests;
 
 #[macro_use]

--- a/prost-build/src/lib.rs
+++ b/prost-build/src/lib.rs
@@ -115,7 +115,7 @@ extern crate heck;
 extern crate itertools;
 extern crate multimap;
 extern crate petgraph;
-extern crate prost;
+extern crate prost_amino as prost;
 extern crate prost_types;
 extern crate tempdir;
 

--- a/prost-build/src/lib.rs
+++ b/prost-build/src/lib.rs
@@ -62,7 +62,7 @@
 //! And finally, in `lib.rs`, include the generated code:
 //!
 //! ```rust,ignore
-//! extern crate prost;
+//! extern crate prost_amino;
 //! #[macro_use]
 //! extern crate prost_derive;
 //!

--- a/prost-derive/src/lib.rs
+++ b/prost-derive/src/lib.rs
@@ -244,7 +244,7 @@ fn try_message(input: TokenStream) -> Result<TokenStream, Error> {
     let expanded = quote! {
         #[allow(non_snake_case, unused_attributes)]
         mod #module {
-            extern crate prost as _prost;
+            extern crate prost_amino as _prost;
             extern crate bytes as _bytes;
 
             use super::*;
@@ -504,7 +504,7 @@ fn try_oneof(input: TokenStream) -> Result<TokenStream, Error> {
         #[allow(non_snake_case, unused_attributes)]
         mod #module {
             extern crate bytes as _bytes;
-            extern crate prost as _prost;
+            extern crate prost_amino as _prost;
             use super::*;
 
             impl #ident {

--- a/src/error.rs
+++ b/src/error.rs
@@ -7,7 +7,7 @@ use std::io;
 
 /// A Protobuf message decoding error.
 ///
-/// `DecodeError` indicates that the input buffer does not caontain a valid
+/// `DecodeError` indicates that the input buffer does not contain a valid
 /// Protobuf message. The error details should be considered 'best effort': in
 /// general it is not possible to exactly pinpoint why data is malformed.
 #[derive(Clone, Debug, PartialEq, Eq)]

--- a/tests/src/amino.rs
+++ b/tests/src/amino.rs
@@ -1,5 +1,5 @@
 
-extern crate prost;
+extern crate prost_amino as prost;
 use prost::Message;
 
 

--- a/tests/src/lib.rs
+++ b/tests/src/lib.rs
@@ -1,5 +1,5 @@
 extern crate bytes;
-extern crate prost;
+extern crate prost_amino;
 extern crate prost_types;
 
 #[macro_use] extern crate prost_derive;


### PR DESCRIPTION
This should resolve #13. I tried to keep the changes as minimalistic as possible. Often just importing using `extern crate prost_amino as prost;` to not having to rename more places then necessary.

There might be still some places left in the documentation (hence the WIP)