### PR TITLE
Simplify and update circleci config:

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,26 +3,25 @@ version: 2
 jobs:
   build:
     docker:
-      - image: iqlusion/rust-ci:20180913.2 # bump cache keys when modifying this
+      - image: circleci/rust
     environment:
     steps:
       - checkout
-      - restore_cache:
-          key: cache-201804050 # bump save_cache key below too
       - run:
-          name: build (nightly, all features)
+          name: build
           command: |
             rustc --version --verbose
             cargo --version --verbose
             cargo build --features=$CARGO_FEATURES
       - run:
-          name: test (nightly, all features)
+          name: test
           command: |
             rustc --version --verbose
             cargo --version --verbose
             cargo test --features=$CARGO_FEATURES
-      - save_cache:
-          key: cache-20180913.2 # bump restore_cache key above too
-          paths:
-            - "~/.cargo"
-            - "./target"
+      - run:
+          name: build --release
+          command: |
+            rustc --version
+            cargo --version
+            cargo build --release


### PR DESCRIPTION
advantage: newer rust versions & consistency across repos,
e.g. tendermint-rs
 - use circleci's rust image
 - update run step names
 - do not use special cache keys