### PR TITLE
Update the bytes dependency and fix clippy errors

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ exclude = [
 
 [dependencies]
 byteorder = "1"
-bytes = "0.4.7"
+bytes = "0.5"
 
 [dev-dependencies]
 env_logger = { version = "0.5", default-features = false }

--- a/benchmarks/Cargo.toml
+++ b/benchmarks/Cargo.toml
@@ -9,7 +9,7 @@ doctest = false
 test = false
 
 [dependencies]
-bytes = "0.4.7"
+bytes = "0.5"
 prost-amino = { path = ".." }
 prost-amino-derive = { path = "../prost-amino-derive" }
 

--- a/benchmarks/build.rs
+++ b/benchmarks/build.rs
@@ -3,13 +3,23 @@ extern crate protobuf;
 
 fn main() {
     let benchmarks = protobuf::include().join("benchmarks");
-    prost_build::compile_protos(&[benchmarks.join("benchmark_messages_proto2.proto")],
-                                &[benchmarks.clone()]).unwrap();
-    prost_build::compile_protos(&[benchmarks.join("benchmark_messages_proto3.proto")],
-                                &[benchmarks]).unwrap();
+    prost_build::compile_protos(
+        &[benchmarks.join("benchmark_messages_proto2.proto")],
+        &[benchmarks.clone()],
+    )
+    .unwrap();
+    prost_build::compile_protos(
+        &[benchmarks.join("benchmark_messages_proto3.proto")],
+        &[benchmarks],
+    )
+    .unwrap();
 
-    println!("cargo:rustc-env=GOOGLE_MESSAGE1={}",
-             protobuf::share().join("google_message1.dat").display());
-    println!("cargo:rustc-env=GOOGLE_MESSAGE2={}",
-             protobuf::share().join("google_message2.dat").display());
+    println!(
+        "cargo:rustc-env=GOOGLE_MESSAGE1={}",
+        protobuf::share().join("google_message1.dat").display()
+    );
+    println!(
+        "cargo:rustc-env=GOOGLE_MESSAGE2={}",
+        protobuf::share().join("google_message2.dat").display()
+    );
 }

--- a/benchmarks/src/lib.rs
+++ b/benchmarks/src/lib.rs
@@ -9,7 +9,6 @@ extern crate prost_amino_derive;
 
 mod varint;
 
-use bytes::IntoBuf;
 use prost::Message;
 
 pub fn bench_message_encode<M>(b: &mut test::Bencher, message: &M) where M: Message  {
@@ -46,7 +45,6 @@ pub fn bench_message_decode<M>(b: &mut test::Bencher, bytes: &[u8]) where M: Mes
 pub const GOOGLE_MESSAGE1: &'static [u8] = include_bytes!(env!("GOOGLE_MESSAGE1"));
 
 pub mod proto2 {
-    use bytes::IntoBuf;
     use prost::Message;
     use test;
 
@@ -73,7 +71,6 @@ pub mod proto2 {
 }
 
 pub mod proto3 {
-    use bytes::IntoBuf;
     use prost::Message;
     use test;
 

--- a/benchmarks/src/lib.rs
+++ b/benchmarks/src/lib.rs
@@ -11,7 +11,10 @@ mod varint;
 
 use prost::Message;
 
-pub fn bench_message_encode<M>(b: &mut test::Bencher, message: &M) where M: Message  {
+pub fn bench_message_encode<M>(b: &mut test::Bencher, message: &M)
+where
+    M: Message,
+{
     let encoded_len = message.encoded_len();
     let mut buf = Vec::with_capacity(encoded_len);
     b.iter(|| {
@@ -22,7 +25,10 @@ pub fn bench_message_encode<M>(b: &mut test::Bencher, message: &M) where M: Mess
     b.bytes = encoded_len as u64;
 }
 
-pub fn bench_message_encode_raw<M>(b: &mut test::Bencher, message: &M) where M: Message  {
+pub fn bench_message_encode_raw<M>(b: &mut test::Bencher, message: &M)
+where
+    M: Message,
+{
     let encoded_len = message.encoded_len();
     let mut buf = Vec::with_capacity(encoded_len);
     b.iter(|| {
@@ -33,7 +39,10 @@ pub fn bench_message_encode_raw<M>(b: &mut test::Bencher, message: &M) where M: 
     b.bytes = encoded_len as u64;
 }
 
-pub fn bench_message_decode<M>(b: &mut test::Bencher, bytes: &[u8]) where M: Message + Default {
+pub fn bench_message_decode<M>(b: &mut test::Bencher, bytes: &[u8])
+where
+    M: Message + Default,
+{
     b.iter(|| {
         test::black_box(M::decode(bytes.into_buf()).unwrap());
     });

--- a/benchmarks/src/varint.rs
+++ b/benchmarks/src/varint.rs
@@ -1,6 +1,5 @@
 use test;
 
-use bytes::IntoBuf;
 
 use prost::encoding::{
     decode_varint,

--- a/benchmarks/src/varint.rs
+++ b/benchmarks/src/varint.rs
@@ -1,11 +1,6 @@
 use test;
 
-
-use prost::encoding::{
-    decode_varint,
-    encode_varint,
-    encoded_len_varint,
-};
+use prost::encoding::{decode_varint, encode_varint, encoded_len_varint};
 
 macro_rules! varint_bench {
     ($encode_name:ident, $decode_name:ident, $encoded_len_name: ident, $encode:expr) => {
@@ -57,38 +52,58 @@ macro_rules! varint_bench {
             });
             b.bytes = 100 * 8;
         }
-    }
+    };
 }
 
 /// Benchmark encoding and decoding 100 varints of mixed width (average 5.5 bytes).
-varint_bench!(encode_varint_mixed, decode_varint_mixed, encoded_len_varint_mixed, |ref mut buf| {
-    for width in 0..10 {
-        let exponent = width * 7;
-        for offset in 0..10 {
-            encode_varint(offset + (1 << exponent), buf);
+varint_bench!(
+    encode_varint_mixed,
+    decode_varint_mixed,
+    encoded_len_varint_mixed,
+    |ref mut buf| {
+        for width in 0..10 {
+            let exponent = width * 7;
+            for offset in 0..10 {
+                encode_varint(offset + (1 << exponent), buf);
+            }
         }
     }
-});
+);
 
 /// Benchmark encoding and decoding 100 small (1 byte) varints.
-varint_bench!(encode_varint_small, decode_varint_small, encoded_len_varint_small, |ref mut buf| {
-    for value in 0..100 {
-        encode_varint(value, buf);
+varint_bench!(
+    encode_varint_small,
+    decode_varint_small,
+    encoded_len_varint_small,
+    |ref mut buf| {
+        for value in 0..100 {
+            encode_varint(value, buf);
+        }
     }
-});
+);
 
 /// Benchmark encoding and decoding 100 medium (5 byte) varints.
-varint_bench!(encode_varint_medium, decode_varint_medium, encoded_len_varint_medium, |ref mut buf| {
-    let start = 1 << 28;
-    for value in start..start + 100 {
-        encode_varint(value, buf);
+varint_bench!(
+    encode_varint_medium,
+    decode_varint_medium,
+    encoded_len_varint_medium,
+    |ref mut buf| {
+        let start = 1 << 28;
+        for value in start..start + 100 {
+            encode_varint(value, buf);
+        }
     }
-});
+);
 
 /// Benchmark encoding and decoding 100 large (10 byte) varints.
-varint_bench!(encode_varint_large, decode_varint_large, encoded_len_varint_large, |ref mut buf| {
-    let start = 1 << 63;
-    for value in start..start + 100 {
-        encode_varint(value, buf);
+varint_bench!(
+    encode_varint_large,
+    decode_varint_large,
+    encoded_len_varint_large,
+    |ref mut buf| {
+        let start = 1 << 63;
+        for value in start..start + 100 {
+            encode_varint(value, buf);
+        }
     }
-});
+);

--- a/conformance/Cargo.toml
+++ b/conformance/Cargo.toml
@@ -5,7 +5,7 @@ authors = ["Dan Burkert <dan@danburkert.com>"]
 publish = false
 
 [dependencies]
-bytes = "0.4.7"
+bytes = "0.5"
 env_logger = { version = "0.5", default-features = false }
 log = "0.3"
 prost-amino = { path = ".." }

--- a/conformance/build.rs
+++ b/conformance/build.rs
@@ -4,10 +4,11 @@ extern crate protobuf;
 fn main() {
     // Emit an environment variable with the path to the conformance test runner so that it can be
     // used in the conformance tests.
-    println!("cargo:rustc-env=CONFORMANCE_TEST_RUNNER={}",
-             protobuf::bin().join("conformance-test-runner").display());
+    println!(
+        "cargo:rustc-env=CONFORMANCE_TEST_RUNNER={}",
+        protobuf::bin().join("conformance-test-runner").display()
+    );
 
     let conformance = protobuf::include().join("conformance");
-    prost_build::compile_protos(&[conformance.join("conformance.proto")],
-                                &[conformance]).unwrap();
+    prost_build::compile_protos(&[conformance.join("conformance.proto")], &[conformance]).unwrap();
 }

--- a/conformance/src/main.rs
+++ b/conformance/src/main.rs
@@ -8,24 +8,14 @@ extern crate prost_amino_derive;
 
 include!(concat!(env!("OUT_DIR"), "/conformance.rs"));
 
-use std::io::{
-    Read,
-    Write,
-    self,
-};
+use std::io::{self, Read, Write};
 
-use bytes::{
-    ByteOrder,
-    LittleEndian,
-};
+use bytes::{ByteOrder, LittleEndian};
 use prost::Message;
 
 use tests::protobuf_test_messages::proto2::TestAllTypesProto2;
 use tests::protobuf_test_messages::proto3::TestAllTypesProto3;
-use tests::{
-    RoundtripResult,
-    roundtrip,
-};
+use tests::{roundtrip, RoundtripResult};
 
 fn main() {
     env_logger::init();
@@ -68,37 +58,44 @@ fn main() {
 fn handle_request(request: ConformanceRequest) -> conformance_response::Result {
     match request.requested_output_format() {
         WireFormat::Unspecified => {
-            return conformance_response::Result::ParseError("output format unspecified".to_string());
-        },
+            return conformance_response::Result::ParseError(
+                "output format unspecified".to_string(),
+            );
+        }
         WireFormat::Json => {
-            return conformance_response::Result::Skipped("JSON output is not supported".to_string());
-        },
+            return conformance_response::Result::Skipped(
+                "JSON output is not supported".to_string(),
+            );
+        }
         WireFormat::Protobuf => (),
     };
 
     let buf = match request.payload {
         None => return conformance_response::Result::ParseError("no payload".to_string()),
-        Some(conformance_request::Payload::JsonPayload(_)) =>
-            return conformance_response::Result::Skipped("JSON input is not supported".to_string()),
+        Some(conformance_request::Payload::JsonPayload(_)) => {
+            return conformance_response::Result::Skipped("JSON input is not supported".to_string())
+        }
         Some(conformance_request::Payload::ProtobufPayload(buf)) => buf,
     };
 
     let roundtrip = match &*request.message_type {
         "protobuf_test_messages.proto2.TestAllTypesProto2" => roundtrip::<TestAllTypesProto2>(&buf),
         "protobuf_test_messages.proto3.TestAllTypesProto3" => roundtrip::<TestAllTypesProto3>(&buf),
-         _ => return conformance_response::Result::ParseError(
-             format!("unknown message type: {}", request.message_type)),
+        _ => {
+            return conformance_response::Result::ParseError(format!(
+                "unknown message type: {}",
+                request.message_type
+            ))
+        }
     };
 
     match roundtrip {
-        RoundtripResult::Ok(buf) => {
-            conformance_response::Result::ProtobufPayload(buf)
-        },
+        RoundtripResult::Ok(buf) => conformance_response::Result::ProtobufPayload(buf),
         RoundtripResult::DecodeError(error) => {
             conformance_response::Result::ParseError(error.to_string())
-        },
+        }
         RoundtripResult::Error(error) => {
             conformance_response::Result::RuntimeError(error.to_string())
-        },
+        }
     }
 }

--- a/conformance/tests/conformance.rs
+++ b/conformance/tests/conformance.rs
@@ -7,20 +7,23 @@ use std::process::Command;
 fn test_conformance() {
     // Get the path to the proto-conformance binary. Adapted from
     // https://github.com/rust-lang/cargo/blob/19fdb308cdbb25faf4f1e25a71351d8d603fa447/tests/cargotest/support/mod.rs#L306.
-    let proto_conformance = env::current_exe().map(|mut path| {
-        path.pop();
-        if path.ends_with("deps") {
+    let proto_conformance = env::current_exe()
+        .map(|mut path| {
             path.pop();
-        }
-        path.join("conformance")
-    }).unwrap();
+            if path.ends_with("deps") {
+                path.pop();
+            }
+            path.join("conformance")
+        })
+        .unwrap();
 
     let status = Command::new(env!("CONFORMANCE_TEST_RUNNER"))
-                         .arg("--enforce_recommended")
-                         .arg("--failure_list").arg("failing_tests.txt")
-                         .arg(proto_conformance)
-                         .status()
-                         .expect("failed to execute conformance-test-runner");
+        .arg("--enforce_recommended")
+        .arg("--failure_list")
+        .arg("failing_tests.txt")
+        .arg(proto_conformance)
+        .status()
+        .expect("failed to execute conformance-test-runner");
 
     assert!(status.success(), "proto conformance test failed");
 }

--- a/prost-amino-derive/src/field/message.rs
+++ b/prost-amino-derive/src/field/message.rs
@@ -2,14 +2,7 @@ use failure::Error;
 use proc_macro2::TokenStream;
 use syn::Meta;
 
-use field::{
-    word_attr,
-    tag_attr,
-    set_option,
-    set_bool,
-    amino_name_attr,
-    Label,
-};
+use field::{amino_name_attr, set_bool, set_option, tag_attr, word_attr, Label};
 
 use super::compute_disfix;
 
@@ -53,7 +46,10 @@ impl Field {
 
         match unknown_attrs.len() {
             0 => (),
-            1 => bail!("unknown attribute for message field: {:?}", unknown_attrs[0]),
+            1 => bail!(
+                "unknown attribute for message field: {:?}",
+                unknown_attrs[0]
+            ),
             _ => bail!("unknown attributes for message field: {:?}", unknown_attrs),
         }
 

--- a/prost-amino-derive/src/field/message.rs
+++ b/prost-amino-derive/src/field/message.rs
@@ -96,13 +96,13 @@ impl Field {
             },
             Label::Required => quote! {
                 let pre = vec![#(#amino_prefix),*];
-                buf.put(pre);
+                buf.put(pre.as_ref());
                 _prost::encoding::message::encode(#tag, &#ident, buf);
             },
             Label::Repeated => quote! {
                 for msg in &#ident {
                     let pre = vec![#(#amino_prefix),*];
-                    buf.put(pre);
+                    buf.put(pre.as_ref());
                     _prost::encoding::message::encode(#tag, msg, buf);
                 }
             },

--- a/prost-amino-derive/src/field/mod.rs
+++ b/prost-amino-derive/src/field/mod.rs
@@ -8,16 +8,7 @@ use std::slice;
 
 use failure::Error;
 use proc_macro2::TokenStream;
-use syn::{
-    Attribute,
-    Ident,
-    Lit,
-    LitBool,
-    Meta,
-    MetaList,
-    MetaNameValue,
-    NestedMeta,
-};
+use syn::{Attribute, Ident, Lit, LitBool, Meta, MetaList, MetaNameValue, NestedMeta};
 
 use super::compute_disfix;
 
@@ -34,7 +25,6 @@ pub enum Field {
 }
 
 impl Field {
-
     /// Creates a new `Field` from an iterator of field attributes.
     ///
     /// If the meta items are invalid, an error will be returned.
@@ -149,7 +139,7 @@ impl Field {
                         ScalarWrapper(&#ident)
                     }
                 }
-            },
+            }
             Field::Map(ref map) => {
                 let wrapper = map.debug(quote!(MapWrapper));
                 quote! {
@@ -158,7 +148,7 @@ impl Field {
                         MapWrapper(&#ident)
                     }
                 }
-            },
+            }
             _ => quote!(&#ident),
         }
     }
@@ -192,11 +182,7 @@ impl Label {
     }
 
     fn variants() -> slice::Iter<'static, Label> {
-        const VARIANTS: &'static [Label] = &[
-            Label::Optional,
-            Label::Required,
-            Label::Repeated,
-        ];
+        const VARIANTS: &'static [Label] = &[Label::Optional, Label::Required, Label::Repeated];
         VARIANTS.iter()
     }
 
@@ -228,23 +214,32 @@ impl fmt::Display for Label {
 
 /// Get the items belonging to the 'prost' list attribute, e.g. `#[prost(foo, bar="baz")]`.
 fn prost_attrs(attrs: Vec<Attribute>) -> Result<Vec<Meta>, Error> {
-    Ok(attrs.iter().flat_map(Attribute::interpret_meta).flat_map(|meta| match meta {
-        Meta::List(MetaList { ident, nested, .. }) => if ident == "prost" {
-            nested.into_iter().collect()
-        } else {
-            Vec::new()
-        },
-        _ => Vec::new(),
-    }).flat_map(|attr| -> Result<_, _> {
-        match attr {
-            NestedMeta::Meta(attr) => Ok(attr),
-            NestedMeta::Literal(lit) => bail!("invalid prost attribute: {:?}", lit),
-        }
-    }).collect())
+    Ok(attrs
+        .iter()
+        .flat_map(Attribute::interpret_meta)
+        .flat_map(|meta| match meta {
+            Meta::List(MetaList { ident, nested, .. }) => {
+                if ident == "prost" {
+                    nested.into_iter().collect()
+                } else {
+                    Vec::new()
+                }
+            }
+            _ => Vec::new(),
+        })
+        .flat_map(|attr| -> Result<_, _> {
+            match attr {
+                NestedMeta::Meta(attr) => Ok(attr),
+                NestedMeta::Literal(lit) => bail!("invalid prost attribute: {:?}", lit),
+            }
+        })
+        .collect())
 }
 
 pub fn set_option<T>(option: &mut Option<T>, value: T, message: &str) -> Result<(), Error>
-where T: fmt::Debug {
+where
+    T: fmt::Debug,
+{
     if let Some(ref existing) = *option {
         bail!("{}: {:?} and {:?}", message, existing, value);
     }
@@ -261,7 +256,6 @@ pub fn set_bool(b: &mut bool, message: &str) -> Result<(), Error> {
     }
 }
 
-
 /// Unpacks an attribute into a (key, boolean) pair, returning the boolean value.
 /// If the key doesn't match the attribute, `None` is returned.
 fn bool_attr(key: &str, attr: &Meta) -> Result<Option<bool>, Error> {
@@ -274,15 +268,23 @@ fn bool_attr(key: &str, attr: &Meta) -> Result<Option<bool>, Error> {
             // TODO(rustlang/rust#23121): slice pattern matching would make this much nicer.
             if meta_list.nested.len() == 1 {
                 if let NestedMeta::Literal(Lit::Bool(LitBool { value, .. })) = meta_list.nested[0] {
-                    return Ok(Some(value))
+                    return Ok(Some(value));
                 }
             }
             bail!("invalid {} attribute", key);
-        },
-        Meta::NameValue(MetaNameValue { lit: Lit::Str(ref lit), .. }) => {
-            lit.value().parse::<bool>().map_err(Error::from).map(Option::Some)
-        },
-        Meta::NameValue(MetaNameValue { lit: Lit::Bool(LitBool{ value, .. }), .. }) => Ok(Some(value)),
+        }
+        Meta::NameValue(MetaNameValue {
+            lit: Lit::Str(ref lit),
+            ..
+        }) => lit
+            .value()
+            .parse::<bool>()
+            .map_err(Error::from)
+            .map(Option::Some),
+        Meta::NameValue(MetaNameValue {
+            lit: Lit::Bool(LitBool { value, .. }),
+            ..
+        }) => Ok(Some(value)),
         _ => bail!("invalid {} attribute", key),
     }
 }
@@ -309,16 +311,15 @@ fn tag_attr(attr: &Meta) -> Result<Option<u32>, Error> {
                 }
             }
             bail!("invalid tag attribute: {:?}", attr);
-        },
-        Meta::NameValue(ref meta_name_value) => {
-            match meta_name_value.lit {
-                Lit::Str(ref lit) => lit.value()
-                                        .parse::<u32>()
-                                        .map_err(Error::from)
-                                        .map(Option::Some),
-                Lit::Int(ref lit) => Ok(Some(lit.value() as u32)),
-                _ => bail!("invalid tag attribute: {:?}", attr),
-            }
+        }
+        Meta::NameValue(ref meta_name_value) => match meta_name_value.lit {
+            Lit::Str(ref lit) => lit
+                .value()
+                .parse::<u32>()
+                .map_err(Error::from)
+                .map(Option::Some),
+            Lit::Int(ref lit) => Ok(Some(lit.value() as u32)),
+            _ => bail!("invalid tag attribute: {:?}", attr),
         },
         _ => bail!("invalid tag attribute: {:?}", attr),
     }
@@ -329,14 +330,9 @@ fn amino_name_attr(attr: &Meta) -> Result<Option<String>, Error> {
         return Ok(None);
     }
     match *attr {
-
-        Meta::NameValue(ref meta_name_value) => {
-            match meta_name_value.lit {
-                Lit::Str(ref lit) => {
-                    Ok(Some(lit.value()))
-                },
-                _ => bail!("invalid tag attribute: {:?}", attr),
-            }
+        Meta::NameValue(ref meta_name_value) => match meta_name_value.lit {
+            Lit::Str(ref lit) => Ok(Some(lit.value())),
+            _ => bail!("invalid tag attribute: {:?}", attr),
         },
         _ => bail!("invalid tag attribute: {:?}", attr),
     }
@@ -357,14 +353,16 @@ fn tags_attr(attr: &Meta) -> Result<Option<Vec<u32>>, Error> {
                 }
             }
             return Ok(Some(tags));
-        },
-        Meta::NameValue(MetaNameValue { lit: Lit::Str(ref lit), .. }) => {
-            lit.value()
-               .split(',')
-               .map(|s| s.trim().parse::<u32>().map_err(Error::from))
-               .collect::<Result<Vec<u32>, _>>()
-               .map(|tags| Some(tags))
-        },
+        }
+        Meta::NameValue(MetaNameValue {
+            lit: Lit::Str(ref lit),
+            ..
+        }) => lit
+            .value()
+            .split(',')
+            .map(|s| s.trim().parse::<u32>().map_err(Error::from))
+            .collect::<Result<Vec<u32>, _>>()
+            .map(|tags| Some(tags)),
         _ => bail!("invalid tag attribute: {:?}", attr),
     }
 }

--- a/prost-amino-derive/src/field/mod.rs
+++ b/prost-amino-derive/src/field/mod.rs
@@ -219,7 +219,7 @@ fn prost_attrs(attrs: Vec<Attribute>) -> Result<Vec<Meta>, Error> {
         .flat_map(Attribute::interpret_meta)
         .flat_map(|meta| match meta {
             Meta::List(MetaList { ident, nested, .. }) => {
-                if ident == "prost" {
+                if ident == "prost_amino" {
                     nested.into_iter().collect()
                 } else {
                     Vec::new()

--- a/prost-amino-derive/src/field/oneof.rs
+++ b/prost-amino-derive/src/field/oneof.rs
@@ -1,18 +1,8 @@
 use failure::Error;
 use proc_macro2::TokenStream;
-use syn::{
-    Lit,
-    Meta,
-    MetaNameValue,
-    NestedMeta,
-    Path,
-    parse_str,
-};
+use syn::{parse_str, Lit, Meta, MetaNameValue, NestedMeta, Path};
 
-use field::{
-    tags_attr,
-    set_option,
-};
+use field::{set_option, tags_attr};
 
 #[derive(Clone)]
 pub struct Field {
@@ -29,9 +19,10 @@ impl Field {
         for attr in attrs {
             if attr.name() == "oneof" {
                 let t = match *attr {
-                    Meta::NameValue(MetaNameValue { lit: Lit::Str(ref lit), .. }) => {
-                        parse_str::<Path>(&lit.value())?
-                    }
+                    Meta::NameValue(MetaNameValue {
+                        lit: Lit::Str(ref lit),
+                        ..
+                    }) => parse_str::<Path>(&lit.value())?,
                     Meta::List(ref list) if list.nested.len() == 1 => {
                         // TODO(rustlang/rust#23121): slice pattern matching would make this much nicer.
                         if let NestedMeta::Meta(Meta::Word(ref ident)) = list.nested[0] {
@@ -39,7 +30,7 @@ impl Field {
                         } else {
                             bail!("invalid oneof attribute: item must be an identifier");
                         }
-                    },
+                    }
                     _ => bail!("invalid oneof attribute: {:?}", attr),
                 };
                 set_option(&mut ty, t, "duplicate oneof attribute")?;
@@ -57,7 +48,10 @@ impl Field {
 
         match unknown_attrs.len() {
             0 => (),
-            1 => bail!("unknown attribute for message field: {:?}", unknown_attrs[0]),
+            1 => bail!(
+                "unknown attribute for message field: {:?}",
+                unknown_attrs[0]
+            ),
             _ => bail!("unknown attributes for message field: {:?}", unknown_attrs),
         }
 
@@ -66,10 +60,7 @@ impl Field {
             None => bail!("oneof field is missing a tags attribute"),
         };
 
-        Ok(Some(Field {
-            ty: ty,
-            tags: tags,
-        }))
+        Ok(Some(Field { ty: ty, tags: tags }))
     }
 
     /// Returns a statement which encodes the oneof field.

--- a/prost-amino-derive/src/field/scalar.rs
+++ b/prost-amino-derive/src/field/scalar.rs
@@ -1,33 +1,14 @@
 use std::fmt;
 
 use failure::Error;
-use proc_macro2::{
-    Span,
-    TokenStream,
-};
+use proc_macro2::{Span, TokenStream};
 use quote;
 use syn::{
-    FloatSuffix,
-    Ident,
-    IntSuffix,
-    Lit,
-    LitByteStr,
-    Meta,
-    MetaList,
-    MetaNameValue,
-    NestedMeta,
-    Path,
-    parse_str,
-    self,
+    self, parse_str, FloatSuffix, Ident, IntSuffix, Lit, LitByteStr, Meta, MetaList, MetaNameValue,
+    NestedMeta, Path,
 };
 
-use field::{
-    Label,
-    bool_attr,
-    set_option,
-    tag_attr,
-    amino_name_attr,
-};
+use field::{amino_name_attr, bool_attr, set_option, tag_attr, Label};
 
 use super::compute_disfix;
 
@@ -42,7 +23,6 @@ pub struct Field {
 }
 
 impl Field {
-
     pub fn new(attrs: &[Meta], inferred_tag: Option<u32>) -> Result<Option<Field>, Error> {
         let mut ty = None;
         let mut label = None;
@@ -87,26 +67,30 @@ impl Field {
         };
 
         let has_default = default.is_some();
-        let default = default.map_or_else(|| Ok(DefaultValue::new(&ty)),
-                                          |lit| DefaultValue::from_lit(&ty, lit))?;
+        let default = default.map_or_else(
+            || Ok(DefaultValue::new(&ty)),
+            |lit| DefaultValue::from_lit(&ty, lit),
+        )?;
 
         let kind = match (label, packed, has_default) {
-            (None, Some(true), _) |
-            (Some(Label::Optional), Some(true), _) |
-            (Some(Label::Required), Some(true), _) => {
+            (None, Some(true), _)
+            | (Some(Label::Optional), Some(true), _)
+            | (Some(Label::Required), Some(true), _) => {
                 bail!("packed attribute may only be applied to repeated fields");
-            },
+            }
             (Some(Label::Repeated), Some(true), _) if !ty.is_numeric() => {
                 bail!("packed attribute may only be applied to numeric types");
-            },
+            }
             (Some(Label::Repeated), _, true) => {
                 bail!("repeated fields may not have a default value");
-            },
+            }
 
             (None, _, _) => Kind::Plain(default),
             (Some(Label::Optional), _, _) => Kind::Optional(default),
             (Some(Label::Required), _, _) => Kind::Required(default),
-            (Some(Label::Repeated), packed, false) if packed.unwrap_or(ty.is_numeric()) => Kind::Packed,
+            (Some(Label::Repeated), packed, false) if packed.unwrap_or(ty.is_numeric()) => {
+                Kind::Packed
+            }
             (Some(Label::Repeated), _, false) => Kind::Repeated,
         };
         let amino_prefix: Vec<u8> = match amino_name {
@@ -131,7 +115,7 @@ impl Field {
                 Kind::Plain(default) => {
                     field.kind = Kind::Required(default);
                     Ok(Some(field))
-                },
+                }
                 Kind::Optional(..) => bail!("invalid optional attribute on oneof field"),
                 Kind::Required(..) => bail!("invalid required attribute on oneof field"),
                 Kind::Packed | Kind::Repeated => bail!("invalid repeated attribute on oneof field"),
@@ -150,7 +134,7 @@ impl Field {
                 } else {
                     quote!(encode)
                 }
-            },
+            }
             Kind::Repeated => quote!(encode_repeated),
             Kind::Packed => quote!(encode_packed),
         };
@@ -174,13 +158,13 @@ impl Field {
                         }
                     }
                 }
-            },
+            }
             Kind::Optional(..) => quote! {
                 if let ::std::option::Option::Some(ref value) = #ident {
                     #encode_fn(#tag, value, buf);
                 }
             },
-            Kind::Required(..) | Kind::Repeated | Kind::Packed => quote!{
+            Kind::Required(..) | Kind::Repeated | Kind::Packed => quote! {
                 #encode_fn(#tag, &#ident, buf);
             },
         }
@@ -213,7 +197,7 @@ impl Field {
                         #merge_fn(wire_type, &mut #ident, buf)
                     }
                 }
-            },
+            }
             Kind::Optional(..) => quote! {
                 #merge_fn(wire_type,
                           #ident.get_or_insert_with(Default::default),
@@ -248,11 +232,11 @@ impl Field {
                         0
                     }
                 }
-            },
+            }
             Kind::Optional(..) => quote! {
                 #ident.as_ref().map_or(0, |value| #encoded_len_fn(#tag, value))
             },
-            Kind::Required(..) | Kind::Repeated | Kind::Packed => quote!{
+            Kind::Required(..) | Kind::Repeated | Kind::Packed => quote! {
                 #encoded_len_fn(#tag, &#ident)
             },
         }
@@ -266,7 +250,7 @@ impl Field {
                     Ty::String | Ty::Bytes => quote!(#ident.clear()),
                     _ => quote!(#ident = #default),
                 }
-            },
+            }
             Kind::Optional(_) => quote!(#ident = ::std::option::Option::None),
             Kind::Repeated | Kind::Packed => quote!(#ident.clear()),
         }
@@ -307,8 +291,7 @@ impl Field {
         let wrapper = self.debug_inner(quote!(Inner));
         let inner_ty = self.ty.rust_type();
         match self.kind {
-            Kind::Plain(_) |
-            Kind::Required(_) => self.debug_inner(wrapper_name),
+            Kind::Plain(_) | Kind::Required(_) => self.debug_inner(wrapper_name),
             Kind::Optional(_) => quote! {
                 struct #wrapper_name<'a>(&'a ::std::option::Option<#inner_ty>);
                 impl<'a> ::std::fmt::Debug for #wrapper_name<'a> {
@@ -318,8 +301,7 @@ impl Field {
                     }
                 }
             },
-            Kind::Repeated |
-            Kind::Packed => {
+            Kind::Repeated | Kind::Packed => {
                 quote! {
                     struct #wrapper_name<'a>(&'a ::std::vec::Vec<#inner_ty>);
                     impl<'a> ::std::fmt::Debug for #wrapper_name<'a> {
@@ -353,7 +335,7 @@ impl Field {
                             self.#ident = value as i32;
                         }
                     }
-                },
+                }
                 Kind::Optional(ref default) => {
                     quote! {
                         pub fn #ident(&self) -> super::#ty {
@@ -364,7 +346,7 @@ impl Field {
                             self.#ident = ::std::option::Option::Some(value as i32);
                         }
                     }
-                },
+                }
                 Kind::Repeated | Kind::Packed => {
                     quote! {
                         pub fn #ident(&self) -> ::std::iter::FilterMap<::std::iter::Cloned<::std::slice::Iter<i32>>,
@@ -375,7 +357,7 @@ impl Field {
                             self.#ident.push(value as i32);
                         }
                     }
-                },
+                }
             })
         } else if let Kind::Optional(ref default) = self.kind {
             let ty = self.ty.rust_ref_type();
@@ -422,7 +404,6 @@ pub enum Ty {
 }
 
 impl Ty {
-
     pub fn from_attr(attr: &Meta) -> Result<Option<Ty>, Error> {
         let ty = match *attr {
             Meta::Word(ref name) if name == "float" => Ty::Float,
@@ -440,10 +421,16 @@ impl Ty {
             Meta::Word(ref name) if name == "bool" => Ty::Bool,
             Meta::Word(ref name) if name == "string" => Ty::String,
             Meta::Word(ref name) if name == "bytes" => Ty::Bytes,
-            Meta::NameValue(MetaNameValue { ref ident, lit: Lit::Str(ref l), .. }) if ident == "enumeration" => {
-                Ty::Enumeration(parse_str::<Path>(&l.value())?)
-            },
-            Meta::List(MetaList { ref ident, ref nested, .. }) if ident == "enumeration" => {
+            Meta::NameValue(MetaNameValue {
+                ref ident,
+                lit: Lit::Str(ref l),
+                ..
+            }) if ident == "enumeration" => Ty::Enumeration(parse_str::<Path>(&l.value())?),
+            Meta::List(MetaList {
+                ref ident,
+                ref nested,
+                ..
+            }) if ident == "enumeration" => {
                 // TODO(rustlang/rust#23121): slice pattern matching would make this much nicer.
                 if nested.len() == 1 {
                     if let NestedMeta::Meta(Meta::Word(ref ident)) = nested[0] {
@@ -454,7 +441,7 @@ impl Ty {
                 } else {
                     bail!("invalid enumeration attribute: only a single identifier is supported");
                 }
-            },
+            }
             _ => return Ok(None),
         };
         Ok(Some(ty))
@@ -491,7 +478,7 @@ impl Ty {
                 }
 
                 Ty::Enumeration(parse_str::<Path>(s[1..s.len() - 1].trim())?)
-            },
+            }
             _ => return error,
         };
         Ok(ty)
@@ -607,7 +594,6 @@ pub enum DefaultValue {
 }
 
 impl DefaultValue {
-
     pub fn from_attr(attr: &Meta) -> Result<Option<Lit>, Error> {
         if attr.name() != "default" {
             return Ok(None);
@@ -626,29 +612,46 @@ impl DefaultValue {
         let is_u64 = *ty == Ty::Uint64 || *ty == Ty::Fixed64;
 
         let default = match lit {
-            Lit::Int(ref lit) if is_i32
-                              && (lit.suffix() == IntSuffix::I32
-                              || lit.suffix() == IntSuffix::None) => DefaultValue::I32(lit.value() as _),
-            Lit::Int(ref lit) if is_i64
-                              && (lit.suffix() == IntSuffix::I64
-                              || lit.suffix() == IntSuffix::None) => DefaultValue::I64(lit.value() as _),
-            Lit::Int(ref lit) if is_u32
-                              && (lit.suffix() == IntSuffix::U32
-                              || lit.suffix() == IntSuffix::None) => DefaultValue::U32(lit.value() as _),
-            Lit::Int(ref lit) if is_u64
-                              && (lit.suffix() == IntSuffix::U64
-                              || lit.suffix() == IntSuffix::None) => DefaultValue::U64(lit.value()),
+            Lit::Int(ref lit)
+                if is_i32
+                    && (lit.suffix() == IntSuffix::I32 || lit.suffix() == IntSuffix::None) =>
+            {
+                DefaultValue::I32(lit.value() as _)
+            }
+            Lit::Int(ref lit)
+                if is_i64
+                    && (lit.suffix() == IntSuffix::I64 || lit.suffix() == IntSuffix::None) =>
+            {
+                DefaultValue::I64(lit.value() as _)
+            }
+            Lit::Int(ref lit)
+                if is_u32
+                    && (lit.suffix() == IntSuffix::U32 || lit.suffix() == IntSuffix::None) =>
+            {
+                DefaultValue::U32(lit.value() as _)
+            }
+            Lit::Int(ref lit)
+                if is_u64
+                    && (lit.suffix() == IntSuffix::U64 || lit.suffix() == IntSuffix::None) =>
+            {
+                DefaultValue::U64(lit.value())
+            }
 
-            Lit::Float(ref lit) if *ty == Ty::Float
-                                && (lit.suffix() == FloatSuffix::F32
-                                || lit.suffix() == FloatSuffix::None) => DefaultValue::F32(lit.value() as _),
+            Lit::Float(ref lit)
+                if *ty == Ty::Float
+                    && (lit.suffix() == FloatSuffix::F32 || lit.suffix() == FloatSuffix::None) =>
+            {
+                DefaultValue::F32(lit.value() as _)
+            }
             Lit::Int(ref lit) if *ty == Ty::Float => DefaultValue::F32(lit.value() as _),
 
-            Lit::Float(ref lit) if *ty == Ty::Double
-                                && (lit.suffix() == FloatSuffix::F64
-                                || lit.suffix() == FloatSuffix::None) => DefaultValue::F64(lit.value()),
+            Lit::Float(ref lit)
+                if *ty == Ty::Double
+                    && (lit.suffix() == FloatSuffix::F64 || lit.suffix() == FloatSuffix::None) =>
+            {
+                DefaultValue::F64(lit.value())
+            }
             Lit::Int(ref lit) if *ty == Ty::Double => DefaultValue::F64(lit.value() as _),
-
 
             Lit::Bool(ref lit) if *ty == Ty::Bool => DefaultValue::Bool(lit.value),
             Lit::Str(ref lit) if *ty == Ty::String => DefaultValue::String(lit.value().clone()),
@@ -660,23 +663,43 @@ impl DefaultValue {
 
                 if let Ty::Enumeration(ref path) = *ty {
                     let variant = Ident::new(value, Span::call_site());
-                    return Ok(DefaultValue::Enumeration(quote!(#path::#variant)))
+                    return Ok(DefaultValue::Enumeration(quote!(#path::#variant)));
                 }
 
                 // Parse special floating point values.
                 if *ty == Ty::Float {
                     match value {
-                        "inf" => return Ok(DefaultValue::Path(parse_str::<Path>("::std::f32::INFINITY")?)),
-                        "-inf" => return Ok(DefaultValue::Path(parse_str::<Path>("::std::f32::NEG_INFINITY")?)),
-                        "nan" => return Ok(DefaultValue::Path(parse_str::<Path>("::std::f32::NAN")?)),
+                        "inf" => {
+                            return Ok(DefaultValue::Path(parse_str::<Path>(
+                                "::std::f32::INFINITY",
+                            )?))
+                        }
+                        "-inf" => {
+                            return Ok(DefaultValue::Path(parse_str::<Path>(
+                                "::std::f32::NEG_INFINITY",
+                            )?))
+                        }
+                        "nan" => {
+                            return Ok(DefaultValue::Path(parse_str::<Path>("::std::f32::NAN")?))
+                        }
                         _ => (),
                     }
                 }
                 if *ty == Ty::Double {
                     match value {
-                        "inf" => return Ok(DefaultValue::Path(parse_str::<Path>("::std::f64::INFINITY")?)),
-                        "-inf" => return Ok(DefaultValue::Path(parse_str::<Path>("::std::f64::NEG_INFINITY")?)),
-                        "nan" => return Ok(DefaultValue::Path(parse_str::<Path>("::std::f64::NAN")?)),
+                        "inf" => {
+                            return Ok(DefaultValue::Path(parse_str::<Path>(
+                                "::std::f64::INFINITY",
+                            )?))
+                        }
+                        "-inf" => {
+                            return Ok(DefaultValue::Path(parse_str::<Path>(
+                                "::std::f64::NEG_INFINITY",
+                            )?))
+                        }
+                        "nan" => {
+                            return Ok(DefaultValue::Path(parse_str::<Path>("::std::f64::NAN")?))
+                        }
                         _ => (),
                     }
                 }
@@ -685,29 +708,49 @@ impl DefaultValue {
                 if value.chars().next() == Some('-') {
                     if let Ok(lit) = syn::parse_str::<Lit>(&value[1..]) {
                         match lit {
-                            Lit::Int(ref lit) if is_i32 && (lit.suffix() == IntSuffix::I32 || lit.suffix() == IntSuffix::None) => {
+                            Lit::Int(ref lit)
+                                if is_i32
+                                    && (lit.suffix() == IntSuffix::I32
+                                        || lit.suffix() == IntSuffix::None) =>
+                            {
                                 return Ok(DefaultValue::I32((!lit.value() + 1) as i32));
-                            },
+                            }
 
-                            Lit::Int(ref lit) if is_i64 && (lit.suffix() == IntSuffix::I64 || lit.suffix() == IntSuffix::None) => {
+                            Lit::Int(ref lit)
+                                if is_i64
+                                    && (lit.suffix() == IntSuffix::I64
+                                        || lit.suffix() == IntSuffix::None) =>
+                            {
                                 return Ok(DefaultValue::I64((!lit.value() + 1) as i64));
-                            },
+                            }
 
-                            Lit::Float(ref lit) if *ty == Ty::Float && (lit.suffix() == FloatSuffix::F32 || lit.suffix() == FloatSuffix::None) => {
+                            Lit::Float(ref lit)
+                                if *ty == Ty::Float
+                                    && (lit.suffix() == FloatSuffix::F32
+                                        || lit.suffix() == FloatSuffix::None) =>
+                            {
                                 return Ok(DefaultValue::F32(-lit.value() as f32));
-                            },
+                            }
 
-                            Lit::Float(ref lit) if *ty == Ty::Double && (lit.suffix() == FloatSuffix::F64 || lit.suffix() == FloatSuffix::None) => {
+                            Lit::Float(ref lit)
+                                if *ty == Ty::Double
+                                    && (lit.suffix() == FloatSuffix::F64
+                                        || lit.suffix() == FloatSuffix::None) =>
+                            {
                                 return Ok(DefaultValue::F64(-lit.value()));
-                            },
+                            }
 
-                            Lit::Int(ref lit) if *ty == Ty::Float && lit.suffix() == IntSuffix::None => {
+                            Lit::Int(ref lit)
+                                if *ty == Ty::Float && lit.suffix() == IntSuffix::None =>
+                            {
                                 return Ok(DefaultValue::F32(-(lit.value() as f32)));
-                            },
+                            }
 
-                            Lit::Int(ref lit) if *ty == Ty::Double && lit.suffix() == IntSuffix::None => {
+                            Lit::Int(ref lit)
+                                if *ty == Ty::Double && lit.suffix() == IntSuffix::None =>
+                            {
                                 return Ok(DefaultValue::F64(-(lit.value() as f64)));
-                            },
+                            }
 
                             _ => (),
                         }
@@ -719,7 +762,7 @@ impl DefaultValue {
                     _ => (),
                 }
                 bail!("invalid default value: {}", quote!(#value));
-            },
+            }
             _ => bail!("invalid default value: {}", quote!(#lit)),
         };
 
@@ -738,19 +781,23 @@ impl DefaultValue {
             Ty::Bool => DefaultValue::Bool(false),
             Ty::String => DefaultValue::String(String::new()),
             Ty::Bytes => DefaultValue::Bytes(Vec::new()),
-            Ty::Enumeration(ref path) => return DefaultValue::Enumeration(quote!(#path::default())),
+            Ty::Enumeration(ref path) => {
+                return DefaultValue::Enumeration(quote!(#path::default()))
+            }
         }
     }
 
     pub fn owned(&self) -> TokenStream {
         match *self {
-            DefaultValue::String(ref value) if value.is_empty() => quote!(::std::string::String::new()),
+            DefaultValue::String(ref value) if value.is_empty() => {
+                quote!(::std::string::String::new())
+            }
             DefaultValue::String(ref value) => quote!(#value.to_owned()),
             DefaultValue::Bytes(ref value) if value.is_empty() => quote!(::std::vec::Vec::new()),
             DefaultValue::Bytes(ref value) => {
                 let lit = LitByteStr::new(value, Span::call_site());
                 quote!(#lit.to_owned())
-            },
+            }
 
             ref other => other.typed(),
         }
@@ -776,10 +823,10 @@ impl quote::ToTokens for DefaultValue {
             DefaultValue::U64(value) => value.to_tokens(tokens),
             DefaultValue::Bool(value) => value.to_tokens(tokens),
             DefaultValue::String(ref value) => value.to_tokens(tokens),
-            DefaultValue::Bytes(ref value) => LitByteStr::new(value, Span::call_site()).to_tokens(tokens),
-            DefaultValue::Enumeration(ref value) => {
-                value.to_tokens(tokens)
-            },
+            DefaultValue::Bytes(ref value) => {
+                LitByteStr::new(value, Span::call_site()).to_tokens(tokens)
+            }
+            DefaultValue::Enumeration(ref value) => value.to_tokens(tokens),
             DefaultValue::Path(ref value) => value.to_tokens(tokens),
         }
     }

--- a/prost-amino-derive/src/lib.rs
+++ b/prost-amino-derive/src/lib.rs
@@ -271,7 +271,7 @@ fn try_message(input: TokenStream) -> Result<TokenStream, Error> {
 
                 #[allow(unused_variables)]
                 fn merge_field<B>(&mut self, buf: &mut B) -> ::std::result::Result<(), _prost::DecodeError>
-                where B: _prost::bytes::BufMut {
+                where B: _prost::bytes::Buf {
                     #struct_name
                     if #is_registered {
                         // skip some bytes: varint(total_len) || prefix_bytes

--- a/prost-amino-derive/src/lib.rs
+++ b/prost-amino-derive/src/lib.rs
@@ -89,7 +89,7 @@ fn try_message(input: TokenStream) -> Result<TokenStream, Error> {
             quote! {
                 // add prefix bytes for registered types:
                 let pre = vec![#(#p),*];
-                buf.put(pre);
+                buf.put(pre.as_ref());
             }
         }
         None => quote!(),

--- a/prost-amino-derive/src/lib.rs
+++ b/prost-amino-derive/src/lib.rs
@@ -244,13 +244,12 @@ fn try_message(input: TokenStream) -> Result<TokenStream, Error> {
         #[allow(non_snake_case, unused_attributes)]
         mod #module {
             extern crate prost_amino as _prost;
-            extern crate bytes as _bytes;
 
             use super::*;
 
             impl _prost::Message for #ident {
                 #[allow(unused_variables)]
-                fn encode_raw<B>(&self, buf: &mut B) where B: _bytes::BufMut {
+                fn encode_raw<B>(&self, buf: &mut B) where B: ::_prost::bytes::BufMut  {
                     if #is_registered {
                         // TODO: in go-amino this only get length-prefixed if MarhsalBinary is used
                         // opposed to MarshalBinaryBare
@@ -265,7 +264,7 @@ fn try_message(input: TokenStream) -> Result<TokenStream, Error> {
 
                 #[allow(unused_variables)]
                 fn merge_field<B>(&mut self, buf: &mut B) -> ::std::result::Result<(), _prost::DecodeError>
-                where B: _bytes::Buf {
+                where B: ::_prost::bytes::Buf {
                     #struct_name
                     if #is_registered {
                         // skip some bytes: varint(total_len) || prefix_bytes
@@ -500,12 +499,11 @@ fn try_oneof(input: TokenStream) -> Result<TokenStream, Error> {
     let expanded = quote! {
         #[allow(non_snake_case, unused_attributes)]
         mod #module {
-            extern crate bytes as _bytes;
             extern crate prost_amino as _prost;
             use super::*;
 
             impl #ident {
-                pub fn encode<B>(&self, buf: &mut B) where B: _bytes::BufMut {
+                pub fn encode<B>(&self, buf: &mut B) where B: ::_prost::bytes::BufMut {
                     match *self {
                         #(#encode,)*
                     }
@@ -516,7 +514,7 @@ fn try_oneof(input: TokenStream) -> Result<TokenStream, Error> {
                                 wire_type: _prost::encoding::WireType,
                                 buf: &mut B)
                                 -> ::std::result::Result<(), _prost::DecodeError>
-                where B: _bytes::Buf {
+                where B: ::_prost::bytes::Buf {
                     match tag {
                         #(#merge,)*
                         _ => unreachable!(concat!("invalid ", stringify!(#ident), " tag: {}"), tag),

--- a/prost-amino-derive/src/lib.rs
+++ b/prost-amino-derive/src/lib.rs
@@ -256,7 +256,7 @@ fn try_message(input: TokenStream) -> Result<TokenStream, Error> {
 
             impl _prost::Message for #ident {
                 #[allow(unused_variables)]
-                fn encode_raw<B>(&self, buf: &mut B) where B: ::_prost::bytes::BufMut  {
+                fn encode_raw<B>(&self, buf: &mut B) where B: _prost::bytes::BufMut  {
                     if #is_registered {
                         // TODO: in go-amino this only get length-prefixed if MarhsalBinary is used
                         // opposed to MarshalBinaryBare
@@ -271,7 +271,7 @@ fn try_message(input: TokenStream) -> Result<TokenStream, Error> {
 
                 #[allow(unused_variables)]
                 fn merge_field<B>(&mut self, buf: &mut B) -> ::std::result::Result<(), _prost::DecodeError>
-                where B: ::_prost::bytes::Buf {
+                where B: _prost::bytes::Buf {
                     #struct_name
                     if #is_registered {
                         // skip some bytes: varint(total_len) || prefix_bytes
@@ -536,7 +536,7 @@ fn try_oneof(input: TokenStream) -> Result<TokenStream, Error> {
             use super::*;
 
             impl #ident {
-                pub fn encode<B>(&self, buf: &mut B) where B: ::_prost::bytes::BufMut {
+                pub fn encode<B>(&self, buf: &mut B) where B: _prost::bytes::BufMut {
                     match *self {
                         #(#encode,)*
                     }
@@ -547,7 +547,7 @@ fn try_oneof(input: TokenStream) -> Result<TokenStream, Error> {
                                 wire_type: _prost::encoding::WireType,
                                 buf: &mut B)
                                 -> ::std::result::Result<(), _prost::DecodeError>
-                where B: ::_prost::bytes::Buf {
+                where B: _prost::bytes::Buf {
                     match tag {
                         #(#merge,)*
                         _ => unreachable!(concat!("invalid ", stringify!(#ident), " tag: {}"), tag),

--- a/prost-amino-derive/src/lib.rs
+++ b/prost-amino-derive/src/lib.rs
@@ -17,20 +17,12 @@ use failure::Error;
 use itertools::Itertools;
 use proc_macro::TokenStream;
 use proc_macro2::Span;
+use sha2::{Digest, Sha256};
 use syn::punctuated::Punctuated;
 use syn::{
-    Data,
-    DataEnum,
-    DataStruct,
-    DeriveInput,
-    Expr,
-    Fields,
-    FieldsNamed,
-    FieldsUnnamed,
-    Ident,
+    Data, DataEnum, DataStruct, DeriveInput, Expr, Fields, FieldsNamed, FieldsUnnamed, Ident,
     Variant,
 };
-use sha2::{Digest, Sha256};
 
 mod field;
 
@@ -40,11 +32,10 @@ fn try_message(input: TokenStream) -> Result<TokenStream, Error> {
     let input: DeriveInput = syn::parse(input)?;
 
     let top_level_attrs: Vec<syn::Attribute> = input.attrs;
-    let amino_name_attrs: Vec<syn::Attribute> = top_level_attrs.
-        into_iter().
-        filter(|a| a.
-            path.segments.first().unwrap().
-            value().ident == "amino_name").collect();
+    let amino_name_attrs: Vec<syn::Attribute> = top_level_attrs
+        .into_iter()
+        .filter(|a| a.path.segments.first().unwrap().value().ident == "amino_name")
+        .collect();
     if amino_name_attrs.len() > 1 {
         bail!("got more than one registered amino_name");
     }
@@ -54,16 +45,16 @@ fn try_message(input: TokenStream) -> Result<TokenStream, Error> {
         match amino_name_attrs.first() {
             Some(att) => {
                 let tts = att.tts.clone().into_iter().collect::<Vec<_>>();
-// for example:
-//                [
-//                    Punct {
-//                        op: '=',
-//                        spacing: Alone
-//                    },
-//                    Literal {
-//                        lit: "tendermint/socketpv/SignHeartbeatMsg"
-//                    }
-//                ]
+                // for example:
+                //                [
+                //                    Punct {
+                //                        op: '=',
+                //                        spacing: Alone
+                //                    },
+                //                    Literal {
+                //                        lit: "tendermint/socketpv/SignHeartbeatMsg"
+                //                    }
+                //                ]
                 if tts.len() != 2 {
                     None
                 } else {
@@ -104,7 +95,6 @@ fn try_message(input: TokenStream) -> Result<TokenStream, Error> {
         None => quote!(),
     };
 
-
     let ident = input.ident;
 
     let variant_data = match input.data {
@@ -113,24 +103,35 @@ fn try_message(input: TokenStream) -> Result<TokenStream, Error> {
         Data::Union(..) => bail!("Message can not be derived for a union"),
     };
 
-    if !input.generics.params.is_empty() ||
-        input.generics.where_clause.is_some() {
+    if !input.generics.params.is_empty() || input.generics.where_clause.is_some() {
         bail!("Message may not be derived for generic type");
     }
 
     let fields = match variant_data {
-        DataStruct { fields: Fields::Named(FieldsNamed { named: fields, .. }), .. } |
-        DataStruct { fields: Fields::Unnamed(FieldsUnnamed { unnamed: fields, .. }), .. } => {
-            fields.into_iter().collect()
+        DataStruct {
+            fields: Fields::Named(FieldsNamed { named: fields, .. }),
+            ..
         }
-        DataStruct { fields: Fields::Unit, .. } => Vec::new(),
+        | DataStruct {
+            fields:
+                Fields::Unnamed(FieldsUnnamed {
+                    unnamed: fields, ..
+                }),
+            ..
+        } => fields.into_iter().collect(),
+        DataStruct {
+            fields: Fields::Unit,
+            ..
+        } => Vec::new(),
     };
 
     let mut next_tag: u32 = 0;
-    let mut fields = fields.into_iter()
+    let mut fields = fields
+        .into_iter()
         .enumerate()
         .flat_map(|(idx, field)| {
-            let field_ident = field.ident
+            let field_ident = field
+                .ident
                 .unwrap_or_else(|| Ident::new(&idx.to_string(), Span::call_site()));
             match Field::new(field.attrs, Some(next_tag)) {
                 Ok(Some(field)) => {
@@ -138,8 +139,9 @@ fn try_message(input: TokenStream) -> Result<TokenStream, Error> {
                     Some(Ok((field_ident, field)))
                 }
                 Ok(None) => None,
-                Err(err) => Some(Err(err.context(format!("invalid message field {}.{}",
-                                                         ident, field_ident)))),
+                Err(err) => Some(Err(
+                    err.context(format!("invalid message field {}.{}", ident, field_ident))
+                )),
             }
         })
         .collect::<Result<Vec<(Ident, Field)>, failure::Context<String>>>()?;
@@ -154,7 +156,10 @@ fn try_message(input: TokenStream) -> Result<TokenStream, Error> {
     fields.sort_by_key(|&(_, ref field)| field.tags().into_iter().min().unwrap());
     let fields = fields;
 
-    let mut tags = fields.iter().flat_map(|&(_, ref field)| field.tags()).collect::<Vec<_>>();
+    let mut tags = fields
+        .iter()
+        .flat_map(|&(_, ref field)| field.tags())
+        .collect::<Vec<_>>();
     let num_tags = tags.len();
     tags.sort();
     tags.dedup();
@@ -165,20 +170,22 @@ fn try_message(input: TokenStream) -> Result<TokenStream, Error> {
     // Put impls in a special module, so that 'extern crate' can be used.
     let module = Ident::new(&format!("{}_MESSAGE", ident), Span::call_site());
 
-    let encoded_len = fields.iter()
-        .map(|&(ref field_ident, ref field)| {
-            field.encoded_len(quote!(self.#field_ident))
-        });
+    let encoded_len = fields
+        .iter()
+        .map(|&(ref field_ident, ref field)| field.encoded_len(quote!(self.#field_ident)));
     let encoded_len2 = encoded_len.clone();
 
-    let encode = fields.iter()
-        .map(|&(ref field_ident, ref field)| {
-            field.encode(quote!(self.#field_ident))
-        });
+    let encode = fields
+        .iter()
+        .map(|&(ref field_ident, ref field)| field.encode(quote!(self.#field_ident)));
 
     let merge = fields.iter().map(|&(ref field_ident, ref field)| {
         let merge = field.merge(quote!(self.#field_ident));
-        let tags = field.tags().into_iter().map(|tag| quote!(#tag)).intersperse(quote!(|));
+        let tags = field
+            .tags()
+            .into_iter()
+            .map(|tag| quote!(#tag))
+            .intersperse(quote!(|));
         quote!(#(#tags)* => #merge.map_err(|mut error| {
             error.push(STRUCT_NAME, stringify!(#field_ident));
             error
@@ -188,24 +195,25 @@ fn try_message(input: TokenStream) -> Result<TokenStream, Error> {
     let struct_name = if fields.is_empty() {
         quote!()
     } else {
-        quote!(const STRUCT_NAME: &'static str = stringify!(#ident);)
+        quote!(
+            const STRUCT_NAME: &'static str = stringify!(#ident);
+        )
     };
 
     // TODO
     let is_struct = true;
 
-    let clear = fields.iter()
-        .map(|&(ref field_ident, ref field)| {
-            field.clear(quote!(self.#field_ident))
-        });
+    let clear = fields
+        .iter()
+        .map(|&(ref field_ident, ref field)| field.clear(quote!(self.#field_ident)));
 
-    let default = fields.iter()
-        .map(|&(ref field_ident, ref field)| {
-            let value = field.default();
-            quote!(#field_ident: #value,)
-        });
+    let default = fields.iter().map(|&(ref field_ident, ref field)| {
+        let value = field.default();
+        quote!(#field_ident: #value,)
+    });
 
-    let methods = fields.iter()
+    let methods = fields
+        .iter()
         .flat_map(|&(ref field_ident, ref field)| field.methods(field_ident))
         .collect::<Vec<_>>();
     let methods = if methods.is_empty() {
@@ -219,21 +227,20 @@ fn try_message(input: TokenStream) -> Result<TokenStream, Error> {
         }
     };
 
-    let debugs = unsorted_fields.iter()
-        .map(|&(ref field_ident, ref field)| {
-            let wrapper = field.debug(quote!(self.#field_ident));
-            let call = if is_struct {
-                quote!(builder.field(stringify!(#field_ident), &wrapper))
-            } else {
-                quote!(builder.field(&wrapper))
-            };
-            quote! {
-                                         let builder = {
-                                             let wrapper = #wrapper;
-                                             #call
-                                         };
-                                    }
-        });
+    let debugs = unsorted_fields.iter().map(|&(ref field_ident, ref field)| {
+        let wrapper = field.debug(quote!(self.#field_ident));
+        let call = if is_struct {
+            quote!(builder.field(stringify!(#field_ident), &wrapper))
+        } else {
+            quote!(builder.field(&wrapper))
+        };
+        quote! {
+             let builder = {
+                 let wrapper = #wrapper;
+                 #call
+             };
+        }
+    });
     let debug_builder = if is_struct {
         quote!(f.debug_struct(stringify!(#ident)))
     } else {
@@ -326,13 +333,11 @@ pub fn message(input: TokenStream) -> TokenStream {
     try_message(input).unwrap()
 }
 
-
 fn try_enumeration(input: TokenStream) -> Result<TokenStream, Error> {
     let input: DeriveInput = syn::parse(input)?;
     let ident = input.ident;
 
-    if !input.generics.params.is_empty() ||
-        input.generics.where_clause.is_some() {
+    if !input.generics.params.is_empty() || input.generics.where_clause.is_some() {
         bail!("Message may not be derived for generic type");
     }
 
@@ -344,10 +349,18 @@ fn try_enumeration(input: TokenStream) -> Result<TokenStream, Error> {
 
     // Map the variants into 'fields'.
     let mut variants: Vec<(Ident, Expr)> = Vec::new();
-    for Variant { ident, fields, discriminant, .. } in punctuated_variants {
+    for Variant {
+        ident,
+        fields,
+        discriminant,
+        ..
+    } in punctuated_variants
+    {
         match fields {
             Fields::Unit => (),
-            Fields::Named(_) | Fields::Unnamed(_) => bail!("Enumeration variants may not have fields"),
+            Fields::Named(_) | Fields::Unnamed(_) => {
+                bail!("Enumeration variants may not have fields")
+            }
         }
 
         match discriminant {
@@ -364,11 +377,18 @@ fn try_enumeration(input: TokenStream) -> Result<TokenStream, Error> {
 
     // Put impls in a special module, so that 'extern crate' can be used.
     let module = Ident::new(&format!("{}_ENUMERATION", ident), Span::call_site());
-    let is_valid = variants.iter().map(|&(_, ref value)| quote!(#value => true));
-    let from = variants.iter().map(|&(ref variant, ref value)| quote!(#value => ::std::option::Option::Some(#ident::#variant)));
+    let is_valid = variants
+        .iter()
+        .map(|&(_, ref value)| quote!(#value => true));
+    let from = variants.iter().map(
+        |&(ref variant, ref value)| quote!(#value => ::std::option::Option::Some(#ident::#variant)),
+    );
 
     let is_valid_doc = format!("Returns `true` if `value` is a variant of `{}`.", ident);
-    let from_i32_doc = format!("Converts an `i32` to a `{}`, or `None` if `value` is not a valid variant.", ident);
+    let from_i32_doc = format!(
+        "Converts an `i32` to a `{}`, or `None` if `value` is not a valid variant.",
+        ident
+    );
 
     let expanded = quote! {
         #[allow(non_snake_case, unused_attributes)]
@@ -427,18 +447,25 @@ fn try_oneof(input: TokenStream) -> Result<TokenStream, Error> {
         Data::Union(..) => bail!("Oneof can not be derived for a union"),
     };
 
-    if !input.generics.params.is_empty() ||
-        input.generics.where_clause.is_some() {
+    if !input.generics.params.is_empty() || input.generics.where_clause.is_some() {
         bail!("Message may not be derived for generic type");
     }
 
     // Map the variants into 'fields'.
     let mut fields: Vec<(Ident, Field)> = Vec::new();
-    for Variant { attrs, ident: variant_ident, fields: variant_fields, .. } in variants {
+    for Variant {
+        attrs,
+        ident: variant_ident,
+        fields: variant_fields,
+        ..
+    } in variants
+    {
         let variant_fields = match variant_fields {
             Fields::Unit => Punctuated::new(),
-            Fields::Named(FieldsNamed { named: fields, .. }) |
-            Fields::Unnamed(FieldsUnnamed { unnamed: fields, .. }) => fields,
+            Fields::Named(FieldsNamed { named: fields, .. })
+            | Fields::Unnamed(FieldsUnnamed {
+                unnamed: fields, ..
+            }) => fields,
         };
         if variant_fields.len() != 1 {
             bail!("Oneof enum variants must have a single field");
@@ -449,13 +476,19 @@ fn try_oneof(input: TokenStream) -> Result<TokenStream, Error> {
         }
     }
 
-    let mut tags = fields.iter().flat_map(|&(ref variant_ident, ref field)| -> Result<u32, Error> {
-        if field.tags().len() > 1 {
-            bail!("invalid oneof variant {}::{}: oneof variants may only have a single tag",
-                  ident, variant_ident);
-        }
-        Ok(field.tags()[0])
-    }).collect::<Vec<_>>();
+    let mut tags = fields
+        .iter()
+        .flat_map(|&(ref variant_ident, ref field)| -> Result<u32, Error> {
+            if field.tags().len() > 1 {
+                bail!(
+                    "invalid oneof variant {}::{}: oneof variants may only have a single tag",
+                    ident,
+                    variant_ident
+                );
+            }
+            Ok(field.tags()[0])
+        })
+        .collect::<Vec<_>>();
     tags.sort();
     tags.dedup();
     if tags.len() != fields.len() {

--- a/prost-amino-derive/src/lib.rs
+++ b/prost-amino-derive/src/lib.rs
@@ -271,7 +271,7 @@ fn try_message(input: TokenStream) -> Result<TokenStream, Error> {
 
                 #[allow(unused_variables)]
                 fn merge_field<B>(&mut self, buf: &mut B) -> ::std::result::Result<(), _prost::DecodeError>
-                where B: _prost::bytes::Buf {
+                where B: _prost::bytes::BufMut {
                     #struct_name
                     if #is_registered {
                         // skip some bytes: varint(total_len) || prefix_bytes
@@ -547,7 +547,7 @@ fn try_oneof(input: TokenStream) -> Result<TokenStream, Error> {
                                 wire_type: _prost::encoding::WireType,
                                 buf: &mut B)
                                 -> ::std::result::Result<(), _prost::DecodeError>
-                where B: _prost::bytes::Buf {
+                where B: _prost::bytes::BufMut {
                     match tag {
                         #(#merge,)*
                         _ => unreachable!(concat!("invalid ", stringify!(#ident), " tag: {}"), tag),

--- a/prost-amino-derive/src/lib.rs
+++ b/prost-amino-derive/src/lib.rs
@@ -322,7 +322,7 @@ fn try_message(input: TokenStream) -> Result<TokenStream, Error> {
     Ok(expanded.into())
 }
 
-#[proc_macro_derive(Message, attributes(prost, amino_name, aminoDisamb))]
+#[proc_macro_derive(Message, attributes(prost_amino, amino_name, aminoDisamb))]
 pub fn message(input: TokenStream) -> TokenStream {
     try_message(input).unwrap()
 }
@@ -412,7 +412,7 @@ fn try_enumeration(input: TokenStream) -> Result<TokenStream, Error> {
     Ok(expanded.into())
 }
 
-#[proc_macro_derive(Enumeration, attributes(prost))]
+#[proc_macro_derive(Enumeration, attributes(prost_amino))]
 pub fn enumeration(input: TokenStream) -> TokenStream {
     try_enumeration(input).unwrap()
 }
@@ -544,7 +544,7 @@ fn try_oneof(input: TokenStream) -> Result<TokenStream, Error> {
     Ok(expanded.into())
 }
 
-#[proc_macro_derive(Oneof, attributes(prost))]
+#[proc_macro_derive(Oneof, attributes(prost_amino))]
 pub fn oneof(input: TokenStream) -> TokenStream {
     try_oneof(input).unwrap()
 }

--- a/prost-build/Cargo.toml
+++ b/prost-build/Cargo.toml
@@ -10,7 +10,7 @@ readme = "README.md"
 description = "A Protocol Buffers implementation for the Rust Language."
 
 [dependencies]
-bytes = "0.4.7"
+bytes = "0.5"
 env_logger = { version = "0.5", default-features = false }
 heck = "0.3"
 itertools = "0.7"

--- a/prost-build/build.rs
+++ b/prost-build/build.rs
@@ -21,7 +21,10 @@ use std::path::PathBuf;
 
 /// Returns the path to the location of the bundled Protobuf artifacts.
 fn bundle_path() -> PathBuf {
-    env::current_dir().unwrap().join("third-party").join("protobuf")
+    env::current_dir()
+        .unwrap()
+        .join("third-party")
+        .join("protobuf")
 }
 
 /// Returns the path to the `protoc` pointed to by the `PROTOC` environment variable, if it is set.
@@ -32,7 +35,10 @@ fn env_protoc() -> Option<PathBuf> {
     };
 
     if !protoc.exists() {
-        panic!("PROTOC environment variable points to non-existent file ({:?})", protoc);
+        panic!(
+            "PROTOC environment variable points to non-existent file ({:?})",
+            protoc
+        );
     }
 
     Some(protoc)
@@ -66,12 +72,16 @@ fn env_protoc_include() -> Option<PathBuf> {
     };
 
     if !protoc_include.exists() {
-        panic!("PROTOC_INCLUDE environment variable points to non-existent directory ({:?})",
-               protoc_include);
+        panic!(
+            "PROTOC_INCLUDE environment variable points to non-existent directory ({:?})",
+            protoc_include
+        );
     }
     if !protoc_include.is_dir() {
-        panic!("PROTOC_INCLUDE environment variable points to a non-directory file ({:?})",
-               protoc_include);
+        panic!(
+            "PROTOC_INCLUDE environment variable points to a non-directory file ({:?})",
+            protoc_include
+        );
     }
 
     Some(protoc_include)
@@ -83,14 +93,21 @@ fn bundled_protoc_include() -> PathBuf {
 }
 
 fn main() {
-    let protoc = env_protoc().or_else(bundled_protoc).or_else(path_protoc).expect(
-        "Failed to find the protoc binary. The PROTOC environment variable is not set, \
-        there is no bundled protoc for this platform, and protoc is not in the PATH");
+    let protoc = env_protoc()
+        .or_else(bundled_protoc)
+        .or_else(path_protoc)
+        .expect(
+            "Failed to find the protoc binary. The PROTOC environment variable is not set, \
+        there is no bundled protoc for this platform, and protoc is not in the PATH",
+        );
 
     let protoc_include = env_protoc_include().unwrap_or_else(bundled_protoc_include);
 
     println!("cargo:rustc-env=PROTOC={}", protoc.display());
-    println!("cargo:rustc-env=PROTOC_INCLUDE={}", protoc_include.display());
+    println!(
+        "cargo:rustc-env=PROTOC_INCLUDE={}",
+        protoc_include.display()
+    );
     println!("cargo:rerun-if-env-changed=PROTOC");
     println!("cargo:rerun-if-env-changed=PROTOC_INCLUDE");
 }

--- a/prost-build/src/ast.rs
+++ b/prost-build/src/ast.rs
@@ -1,5 +1,5 @@
-use prost_types::source_code_info::Location;
 use prost_types;
+use prost_types::source_code_info::Location;
 
 /// Comments on a Protobuf item.
 #[derive(Debug)]
@@ -16,13 +16,26 @@ pub struct Comments {
 
 impl Comments {
     pub(crate) fn from_location(location: &Location) -> Comments {
-        fn get_lines<S>(comments: S) -> Vec<String> where S: AsRef<str> {
+        fn get_lines<S>(comments: S) -> Vec<String>
+        where
+            S: AsRef<str>,
+        {
             comments.as_ref().lines().map(str::to_owned).collect()
         }
 
-        let leading_detached = location.leading_detached_comments.iter().map(get_lines).collect();
-        let leading = location.leading_comments.as_ref().map_or(Vec::new(), get_lines);
-        let trailing = location.trailing_comments.as_ref().map_or(Vec::new(), get_lines);
+        let leading_detached = location
+            .leading_detached_comments
+            .iter()
+            .map(get_lines)
+            .collect();
+        let leading = location
+            .leading_comments
+            .as_ref()
+            .map_or(Vec::new(), get_lines);
+        let trailing = location
+            .trailing_comments
+            .as_ref()
+            .map_or(Vec::new(), get_lines);
         Comments {
             leading_detached: leading_detached,
             leading: leading,

--- a/prost-build/src/code_generator.rs
+++ b/prost-build/src/code_generator.rs
@@ -4,29 +4,15 @@ use std::collections::{HashMap, HashSet};
 
 use itertools::{Either, Itertools};
 use multimap::MultiMap;
-use prost_types::{
-    DescriptorProto,
-    EnumDescriptorProto,
-    EnumValueDescriptorProto,
-    FieldDescriptorProto,
-    FileDescriptorProto,
-    OneofDescriptorProto,
-    ServiceDescriptorProto,
-    SourceCodeInfo,
-};
 use prost_types::field_descriptor_proto::{Label, Type};
 use prost_types::source_code_info::Location;
+use prost_types::{
+    DescriptorProto, EnumDescriptorProto, EnumValueDescriptorProto, FieldDescriptorProto,
+    FileDescriptorProto, OneofDescriptorProto, ServiceDescriptorProto, SourceCodeInfo,
+};
 
-use ast::{
-    Comments,
-    Method,
-    Service,
-};
-use ident::{
-    to_snake,
-    match_ident,
-    to_upper_camel,
-};
+use ast::{Comments, Method, Service};
+use ident::{match_ident, to_snake, to_upper_camel};
 use message_graph::MessageGraph;
 use Config;
 use Module;
@@ -56,18 +42,23 @@ pub struct CodeGenerator<'a> {
     buf: &'a mut String,
 }
 
-impl <'a> CodeGenerator<'a> {
-    pub fn generate(config: &mut Config,
-                    message_graph: &MessageGraph,
-                    file: FileDescriptorProto,
-                    buf: &mut String) {
-
-        let mut source_info = file.source_code_info.expect("no source code info in request");
+impl<'a> CodeGenerator<'a> {
+    pub fn generate(
+        config: &mut Config,
+        message_graph: &MessageGraph,
+        file: FileDescriptorProto,
+        buf: &mut String,
+    ) {
+        let mut source_info = file
+            .source_code_info
+            .expect("no source code info in request");
         source_info.location.retain(|location| {
             let len = location.path.len();
             len > 0 && len % 2 == 0
         });
-        source_info.location.sort_by_key(|location| location.path.clone());
+        source_info
+            .location
+            .sort_by_key(|location| location.path.clone());
 
         let syntax = match file.syntax.as_ref().map(String::as_str) {
             None | Some("proto2") => Syntax::Proto2,
@@ -86,7 +77,11 @@ impl <'a> CodeGenerator<'a> {
             buf: buf,
         };
 
-        debug!("file: {:?}, package: {:?}", file.name.as_ref().unwrap(), code_gen.package);
+        debug!(
+            "file: {:?}, package: {:?}",
+            file.name.as_ref().unwrap(),
+            code_gen.package
+        );
 
         code_gen.path.push(4);
         for (idx, message) in file.message_type.into_iter().enumerate() {
@@ -113,9 +108,13 @@ impl <'a> CodeGenerator<'a> {
             }
 
             let buf = code_gen.buf;
-            code_gen.config.service_generator.as_mut().map(|service_generator| {
-                service_generator.finalize(buf);
-            });
+            code_gen
+                .config
+                .service_generator
+                .as_mut()
+                .map(|service_generator| {
+                    service_generator.finalize(buf);
+                });
 
             code_gen.path.pop();
         }
@@ -128,16 +127,26 @@ impl <'a> CodeGenerator<'a> {
         let fq_message_name = format!(".{}.{}", self.package, message.name());
 
         // Skip Protobuf well-known types.
-        if self.well_known_type(&fq_message_name).is_some() { return; }
+        if self.well_known_type(&fq_message_name).is_some() {
+            return;
+        }
 
         // Split the nested message types into a vector of normal nested message types, and a map
         // of the map field entry types. The path index of the nested message types is preserved so
         // that comments can be retrieved.
         type NestedTypes = Vec<(DescriptorProto, usize)>;
         type MapTypes = HashMap<String, (FieldDescriptorProto, FieldDescriptorProto)>;
-        let (nested_types, map_types): (NestedTypes, MapTypes) =
-            message.nested_type.into_iter().enumerate().partition_map(|(idx, nested_type)| {
-                if nested_type.options.as_ref().and_then(|options| options.map_entry).unwrap_or(false) {
+        let (nested_types, map_types): (NestedTypes, MapTypes) = message
+            .nested_type
+            .into_iter()
+            .enumerate()
+            .partition_map(|(idx, nested_type)| {
+                if nested_type
+                    .options
+                    .as_ref()
+                    .and_then(|options| options.map_entry)
+                    .unwrap_or(false)
+                {
                     let key = nested_type.field[0].clone();
                     let value = nested_type.field[1].clone();
                     assert_eq!("key", key.name());
@@ -148,14 +157,17 @@ impl <'a> CodeGenerator<'a> {
                 } else {
                     Either::Left((nested_type, idx))
                 }
-        });
+            });
 
         // Split the fields into a vector of the normal fields, and oneof fields.
         // Path indexes are preserved so that comments can be retrieved.
         type Fields = Vec<(FieldDescriptorProto, usize)>;
         type OneofFields = MultiMap<i32, (FieldDescriptorProto, usize)>;
-        let (fields, mut oneof_fields): (Fields, OneofFields) =
-            message.field.into_iter().enumerate().partition_map(|(idx, field)| {
+        let (fields, mut oneof_fields): (Fields, OneofFields) = message
+            .field
+            .into_iter()
+            .enumerate()
+            .partition_map(|(idx, field)| {
                 if let Some(oneof_index) = field.oneof_index {
                     Either::Right((oneof_index, (field, idx)))
                 } else {
@@ -178,8 +190,14 @@ impl <'a> CodeGenerator<'a> {
         self.path.push(2);
         for (field, idx) in fields {
             self.path.push(idx as i32);
-            match field.type_name.as_ref().and_then(|type_name| map_types.get(type_name)) {
-                Some(&(ref key, ref value)) => self.append_map_field(&fq_message_name, field, key, value),
+            match field
+                .type_name
+                .as_ref()
+                .and_then(|type_name| map_types.get(type_name))
+            {
+                Some(&(ref key, ref value)) => {
+                    self.append_map_field(&fq_message_name, field, key, value)
+                }
                 None => self.append_field(&fq_message_name, field),
             }
             self.path.pop();
@@ -190,10 +208,12 @@ impl <'a> CodeGenerator<'a> {
         for (idx, oneof) in message.oneof_decl.iter().enumerate() {
             let idx = idx as i32;
             self.path.push(idx);
-            self.append_oneof_field(&message_name,
-                                    &fq_message_name,
-                                    oneof,
-                                    oneof_fields.get_vec(&idx).unwrap());
+            self.append_oneof_field(
+                &message_name,
+                &fq_message_name,
+                oneof,
+                oneof_fields.get_vec(&idx).unwrap(),
+            );
             self.path.pop();
         }
         self.path.pop();
@@ -222,7 +242,12 @@ impl <'a> CodeGenerator<'a> {
 
             for (idx, oneof) in message.oneof_decl.into_iter().enumerate() {
                 let idx = idx as i32;
-                self.append_oneof(&fq_message_name, oneof, idx, oneof_fields.remove(&idx).unwrap());
+                self.append_oneof(
+                    &fq_message_name,
+                    oneof,
+                    idx,
+                    oneof_fields.remove(&idx).unwrap(),
+                );
             }
 
             self.pop_mod();
@@ -256,17 +281,24 @@ impl <'a> CodeGenerator<'a> {
     fn append_field(&mut self, msg_name: &str, field: FieldDescriptorProto) {
         // TODO(danburkert/prost#19): support groups.
         let type_ = field.type_();
-        if type_ == Type::Group { return; }
+        if type_ == Type::Group {
+            return;
+        }
 
         let repeated = field.label == Some(Label::Repeated as i32);
         let optional = self.optional(&field);
         let ty = self.resolve_type(&field);
 
         let boxed = !repeated
-                 && type_ == Type::Message
-                 && self.message_graph.is_nested(field.type_name(), msg_name);
+            && type_ == Type::Message
+            && self.message_graph.is_nested(field.type_name(), msg_name);
 
-        debug!("    field: {:?}, type: {:?}, boxed: {}", field.name(), ty, boxed);
+        debug!(
+            "    field: {:?}, type: {:?}, boxed: {}",
+            field.name(),
+            ty,
+            boxed
+        );
 
         self.append_doc();
         self.push_indent();
@@ -275,20 +307,28 @@ impl <'a> CodeGenerator<'a> {
         self.buf.push_str(&type_tag);
 
         match field.label() {
-            Label::Optional => if optional {
-                self.buf.push_str(", optional");
-            },
+            Label::Optional => {
+                if optional {
+                    self.buf.push_str(", optional");
+                }
+            }
             Label::Required => self.buf.push_str(", required"),
             Label::Repeated => {
                 self.buf.push_str(", repeated");
-                if can_pack(&field) && !field.options.as_ref().map_or(self.syntax == Syntax::Proto3,
-                                                                      |options| options.packed()) {
+                if can_pack(&field)
+                    && !field
+                        .options
+                        .as_ref()
+                        .map_or(self.syntax == Syntax::Proto3, |options| options.packed())
+                {
                     self.buf.push_str(", packed=\"false\"");
                 }
-            },
+            }
         }
 
-        if boxed { self.buf.push_str(", boxed"); }
+        if boxed {
+            self.buf.push_str(", boxed");
+        }
         self.buf.push_str(", tag=\"");
         self.buf.push_str(&field.number().to_string());
 
@@ -297,7 +337,9 @@ impl <'a> CodeGenerator<'a> {
             if type_ == Type::Bytes {
                 self.buf.push_str("b\\\"");
                 for b in unescape_c_escape_string(default) {
-                    self.buf.extend(ascii::escape_default(b).flat_map(|c| (c as char).escape_default()));
+                    self.buf.extend(
+                        ascii::escape_default(b).flat_map(|c| (c as char).escape_default()),
+                    );
                 }
                 self.buf.push_str("\\\"");
             } else if type_ == Type::Enum {
@@ -316,33 +358,49 @@ impl <'a> CodeGenerator<'a> {
         self.buf.push_str("pub ");
         self.buf.push_str(&to_snake(field.name()));
         self.buf.push_str(": ");
-        if repeated { self.buf.push_str("::std::vec::Vec<"); }
-        else if optional { self.buf.push_str("::std::option::Option<"); }
-        if boxed { self.buf.push_str("::std::boxed::Box<"); }
+        if repeated {
+            self.buf.push_str("::std::vec::Vec<");
+        } else if optional {
+            self.buf.push_str("::std::option::Option<");
+        }
+        if boxed {
+            self.buf.push_str("::std::boxed::Box<");
+        }
         self.buf.push_str(&ty);
-        if boxed { self.buf.push_str(">"); }
-        if repeated || optional { self.buf.push_str(">"); }
+        if boxed {
+            self.buf.push_str(">");
+        }
+        if repeated || optional {
+            self.buf.push_str(">");
+        }
         self.buf.push_str(",\n");
     }
 
-    fn append_map_field(&mut self,
-                        msg_name: &str,
-                        field: FieldDescriptorProto,
-                        key: &FieldDescriptorProto,
-                        value: &FieldDescriptorProto) {
+    fn append_map_field(
+        &mut self,
+        msg_name: &str,
+        field: FieldDescriptorProto,
+        key: &FieldDescriptorProto,
+        value: &FieldDescriptorProto,
+    ) {
         let key_ty = self.resolve_type(key);
         let value_ty = self.resolve_type(value);
 
-        debug!("    map field: {:?}, key type: {:?}, value type: {:?}",
-               field.name(), key_ty, value_ty);
+        debug!(
+            "    map field: {:?}, key type: {:?}, value type: {:?}",
+            field.name(),
+            key_ty,
+            value_ty
+        );
 
         self.append_doc();
         self.push_indent();
 
-        let btree_map = self.config
-                            .btree_map
-                            .iter()
-                            .any(|matcher| match_ident(matcher, msg_name, Some(field.name())));
+        let btree_map = self
+            .config
+            .btree_map
+            .iter()
+            .any(|matcher| match_ident(matcher, msg_name, Some(field.name())));
         let (annotation_ty, rust_ty) = if btree_map {
             ("btree_map", "BTreeMap")
         } else {
@@ -351,40 +409,62 @@ impl <'a> CodeGenerator<'a> {
 
         let key_tag = self.field_type_tag(key);
         let value_tag = self.map_value_type_tag(value);
-        self.buf.push_str(&format!("#[prost({}=\"{}, {}\", tag=\"{}\")]\n",
-                                   annotation_ty,
-                                   key_tag,
-                                   value_tag,
-                                   field.number()));
+        self.buf.push_str(&format!(
+            "#[prost({}=\"{}, {}\", tag=\"{}\")]\n",
+            annotation_ty,
+            key_tag,
+            value_tag,
+            field.number()
+        ));
         self.append_field_attributes(msg_name, field.name());
         self.push_indent();
-        self.buf.push_str(&format!("pub {}: ::std::collections::{}<{}, {}>,\n",
-                                   to_snake(field.name()), rust_ty, key_ty, value_ty));
+        self.buf.push_str(&format!(
+            "pub {}: ::std::collections::{}<{}, {}>,\n",
+            to_snake(field.name()),
+            rust_ty,
+            key_ty,
+            value_ty
+        ));
     }
 
-    fn append_oneof_field(&mut self,
-                          message_name: &str,
-                          fq_message_name: &str,
-                          oneof: &OneofDescriptorProto,
-                          fields: &[(FieldDescriptorProto, usize)]) {
-        let name = format!("{}::{}",
-                           to_snake(message_name),
-                           to_upper_camel(oneof.name()));
+    fn append_oneof_field(
+        &mut self,
+        message_name: &str,
+        fq_message_name: &str,
+        oneof: &OneofDescriptorProto,
+        fields: &[(FieldDescriptorProto, usize)],
+    ) {
+        let name = format!(
+            "{}::{}",
+            to_snake(message_name),
+            to_upper_camel(oneof.name())
+        );
         self.append_doc();
         self.push_indent();
-        self.buf.push_str(&format!("#[prost(oneof=\"{}\", tags=\"{}\")]\n",
-                                   name,
-                                   fields.iter().map(|&(ref field, _)| field.number()).join(", ")));
+        self.buf.push_str(&format!(
+            "#[prost(oneof=\"{}\", tags=\"{}\")]\n",
+            name,
+            fields
+                .iter()
+                .map(|&(ref field, _)| field.number())
+                .join(", ")
+        ));
         self.append_field_attributes(fq_message_name, oneof.name());
         self.push_indent();
-        self.buf.push_str(&format!("pub {}: ::std::option::Option<{}>,\n", to_snake(oneof.name()), name));
+        self.buf.push_str(&format!(
+            "pub {}: ::std::option::Option<{}>,\n",
+            to_snake(oneof.name()),
+            name
+        ));
     }
 
-    fn append_oneof(&mut self,
-                    msg_name: &str,
-                    oneof: OneofDescriptorProto,
-                    idx: i32,
-                    fields: Vec<(FieldDescriptorProto, usize)>) {
+    fn append_oneof(
+        &mut self,
+        msg_name: &str,
+        oneof: OneofDescriptorProto,
+        idx: i32,
+        fields: Vec<(FieldDescriptorProto, usize)>,
+    ) {
         self.path.push(8);
         self.path.push(idx);
         self.append_doc();
@@ -405,7 +485,9 @@ impl <'a> CodeGenerator<'a> {
         for (field, idx) in fields {
             // TODO(danburkert/prost#19): support groups.
             let type_ = field.type_();
-            if type_ == Type::Group { continue; }
+            if type_ == Type::Group {
+                continue;
+            }
 
             self.path.push(idx as i32);
             self.append_doc();
@@ -413,21 +495,32 @@ impl <'a> CodeGenerator<'a> {
 
             self.push_indent();
             let ty_tag = self.field_type_tag(&field);
-            self.buf.push_str(&format!("#[prost({}, tag=\"{}\")]\n", ty_tag, field.number()));
+            self.buf.push_str(&format!(
+                "#[prost({}, tag=\"{}\")]\n",
+                ty_tag,
+                field.number()
+            ));
             self.append_field_attributes(&oneof_name, field.name());
 
             self.push_indent();
             let ty = self.resolve_type(&field);
 
-            let boxed = type_ == Type::Message
-                     && self.message_graph.is_nested(field.type_name(), msg_name);
+            let boxed =
+                type_ == Type::Message && self.message_graph.is_nested(field.type_name(), msg_name);
 
-            debug!("    oneof: {:?}, type: {:?}, boxed: {}", field.name(), ty, boxed);
+            debug!(
+                "    oneof: {:?}, type: {:?}, boxed: {}",
+                field.name(),
+                ty,
+                boxed
+            );
 
             if boxed {
-                self.buf.push_str(&format!("{}(Box<{}>),\n", to_upper_camel(field.name()), ty));
+                self.buf
+                    .push_str(&format!("{}(Box<{}>),\n", to_upper_camel(field.name()), ty));
             } else {
-                self.buf.push_str(&format!("{}({}),\n", to_upper_camel(field.name()), ty));
+                self.buf
+                    .push_str(&format!("{}({}),\n", to_upper_camel(field.name()), ty));
             }
         }
         self.depth -= 1;
@@ -438,10 +531,11 @@ impl <'a> CodeGenerator<'a> {
     }
 
     fn location(&self) -> &Location {
-        let idx = self.source_info
-                      .location
-                      .binary_search_by_key(&&self.path[..], |location| &location.path[..])
-                      .unwrap();
+        let idx = self
+            .source_info
+            .location
+            .binary_search_by_key(&&self.path[..], |location| &location.path[..])
+            .unwrap();
 
         &self.source_info.location[idx]
     }
@@ -457,11 +551,15 @@ impl <'a> CodeGenerator<'a> {
         let enum_name = &desc.name();
         let enum_values = &desc.value;
         let fq_enum_name = format!(".{}.{}", self.package, enum_name);
-        if self.well_known_type(&fq_enum_name).is_some() { return; }
+        if self.well_known_type(&fq_enum_name).is_some() {
+            return;
+        }
 
         self.append_doc();
         self.push_indent();
-        self.buf.push_str("#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, Enumeration)]\n");
+        self.buf.push_str(
+            "#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, Enumeration)]\n",
+        );
         self.append_type_attributes(&fq_enum_name);
         self.push_indent();
         self.buf.push_str("pub enum ");
@@ -495,7 +593,12 @@ impl <'a> CodeGenerator<'a> {
         self.buf.push_str("}\n");
     }
 
-    fn append_enum_value(&mut self, fq_enum_name: &str, value: &EnumValueDescriptorProto, prefix_to_strip: Option<String>) {
+    fn append_enum_value(
+        &mut self,
+        fq_enum_name: &str,
+        value: &EnumValueDescriptorProto,
+        prefix_to_strip: Option<String>,
+    ) {
         self.append_doc();
         self.append_field_attributes(fq_enum_name, &value.name());
         self.push_indent();
@@ -506,10 +609,11 @@ impl <'a> CodeGenerator<'a> {
                 if is_prefixed {
                     let prefix_len = prefix.len();
                     name[prefix_len..].to_string()
+                } else {
+                    name
                 }
-                else { name }
-            },
-            None => name
+            }
+            None => name,
         };
         self.buf.push_str(&name_unprefixed);
         self.buf.push_str(" = ");
@@ -524,37 +628,38 @@ impl <'a> CodeGenerator<'a> {
         let comments = Comments::from_location(self.location());
 
         self.path.push(2);
-        let methods = service.method
-                             .into_iter()
-                             .enumerate()
-                             .map(|(idx, mut method)| {
-                                 debug!("  method: {:?}", method.name());
-                                 self.path.push(idx as i32);
-                                 let comments = Comments::from_location(self.location());
-                                 self.path.pop();
+        let methods = service
+            .method
+            .into_iter()
+            .enumerate()
+            .map(|(idx, mut method)| {
+                debug!("  method: {:?}", method.name());
+                self.path.push(idx as i32);
+                let comments = Comments::from_location(self.location());
+                self.path.pop();
 
-                                 let name = method.name.take().unwrap();
-                                 let input_proto_type = method.input_type.take().unwrap();
-                                 let output_proto_type = method.output_type.take().unwrap();
-                                 let input_type = self.resolve_ident(&input_proto_type);
-                                 let output_type = self.resolve_ident(&output_proto_type);
-                                 let client_streaming = method.client_streaming();
-                                 let server_streaming = method.server_streaming();
+                let name = method.name.take().unwrap();
+                let input_proto_type = method.input_type.take().unwrap();
+                let output_proto_type = method.output_type.take().unwrap();
+                let input_type = self.resolve_ident(&input_proto_type);
+                let output_type = self.resolve_ident(&output_proto_type);
+                let client_streaming = method.client_streaming();
+                let server_streaming = method.server_streaming();
 
-                                 Method {
-                                     name: to_snake(&name),
-                                     proto_name: name,
-                                     comments,
-                                     input_type,
-                                     output_type,
-                                     input_proto_type,
-                                     output_proto_type,
-                                     options: method.options.unwrap_or_default(),
-                                     client_streaming,
-                                     server_streaming,
-                                 }
-                             })
-                             .collect();
+                Method {
+                    name: to_snake(&name),
+                    proto_name: name,
+                    comments,
+                    input_type,
+                    output_type,
+                    input_proto_type,
+                    output_proto_type,
+                    options: method.options.unwrap_or_default(),
+                    client_streaming,
+                    server_streaming,
+                }
+            })
+            .collect();
         self.path.pop();
 
         let service = Service {
@@ -567,7 +672,10 @@ impl <'a> CodeGenerator<'a> {
         };
 
         let buf = &mut self.buf;
-        self.config.service_generator.as_mut().map(move |service_generator| service_generator.generate(service, buf));
+        self.config
+            .service_generator
+            .as_mut()
+            .map(move |service_generator| service_generator.generate(service, buf));
     }
 
     fn push_indent(&mut self) {
@@ -615,7 +723,7 @@ impl <'a> CodeGenerator<'a> {
                 } else {
                     Cow::Owned(self.resolve_ident(field.type_name()))
                 }
-            },
+            }
         }
     }
 
@@ -630,16 +738,16 @@ impl <'a> CodeGenerator<'a> {
         let mut ident_path = ident_path.peekable();
 
         // Skip path elements in common.
-        while local_path.peek().is_some() &&
-              local_path.peek() == ident_path.peek() {
+        while local_path.peek().is_some() && local_path.peek() == ident_path.peek() {
             local_path.next();
             ident_path.next();
         }
 
-        local_path.map(|_| "super".to_string())
-                  .chain(ident_path.map(to_snake))
-                  .chain(Some(to_upper_camel(ident_type)).into_iter())
-                  .join("::")
+        local_path
+            .map(|_| "super".to_string())
+            .chain(ident_path.map(to_snake))
+            .chain(Some(to_upper_camel(ident_type)).into_iter())
+            .join("::")
     }
 
     fn field_type_tag(&self, field: &FieldDescriptorProto) -> Cow<'static, str> {
@@ -661,13 +769,19 @@ impl <'a> CodeGenerator<'a> {
             Type::Bytes => Cow::Borrowed("bytes"),
             Type::Group => Cow::Borrowed("group"),
             Type::Message => Cow::Borrowed("message"),
-            Type::Enum => Cow::Owned(format!("enumeration={:?}", self.resolve_ident(field.type_name()))),
+            Type::Enum => Cow::Owned(format!(
+                "enumeration={:?}",
+                self.resolve_ident(field.type_name())
+            )),
         }
     }
 
     fn map_value_type_tag(&self, field: &FieldDescriptorProto) -> Cow<'static, str> {
         match field.type_() {
-            Type::Enum => Cow::Owned(format!("enumeration({})", self.resolve_ident(field.type_name()))),
+            Type::Enum => Cow::Owned(format!(
+                "enumeration({})",
+                self.resolve_ident(field.type_name())
+            )),
             _ => self.field_type_tag(field),
         }
     }
@@ -686,7 +800,9 @@ impl <'a> CodeGenerator<'a> {
     /// Returns the prost_types name for a well-known Protobuf type, or `None` if the provided
     /// message type is not a well-known type, or prost_types has been disabled.
     fn well_known_type(&self, fq_msg_type: &str) -> Option<&'static str> {
-        if !self.config.prost_types { return None; }
+        if !self.config.prost_types {
+            return None;
+        }
         Some(match fq_msg_type {
             ".google.protobuf.BoolValue" => "bool",
             ".google.protobuf.BytesValue" => "::std::vec::Vec<u8>",
@@ -707,7 +823,9 @@ impl <'a> CodeGenerator<'a> {
             ".google.protobuf.EnumDescriptorProto" => "::prost_types::EnumDescriptorProt",
             ".google.protobuf.EnumOptions" => "::prost_types::EnumOptions",
             ".google.protobuf.EnumValue" => "::prost_types::EnumValue",
-            ".google.protobuf.EnumValueDescriptorProto" => "::prost_types::EnumValueDescriptorProto",
+            ".google.protobuf.EnumValueDescriptorProto" => {
+                "::prost_types::EnumValueDescriptorProto"
+            }
             ".google.protobuf.EnumValueOptions" => "::prost_types::EnumValueOptions",
             ".google.protobuf.ExtensionRangeOptions" => "::prost_types::ExtensionRangeOptions",
             ".google.protobuf.Field" => "::prost_types::Field",
@@ -744,13 +862,23 @@ impl <'a> CodeGenerator<'a> {
 
 /// Returns `true` if the repeated field type can be packed.
 fn can_pack(field: &FieldDescriptorProto) -> bool {
-        match field.type_() {
-            Type::Float   | Type::Double  | Type::Int32    | Type::Int64    |
-            Type::Uint32  | Type::Uint64  | Type::Sint32   | Type::Sint64   |
-            Type::Fixed32 | Type::Fixed64 | Type::Sfixed32 | Type::Sfixed64 |
-            Type::Bool    | Type::Enum => true,
-            _ => false,
-        }
+    match field.type_() {
+        Type::Float
+        | Type::Double
+        | Type::Int32
+        | Type::Int64
+        | Type::Uint32
+        | Type::Uint64
+        | Type::Sint32
+        | Type::Sint64
+        | Type::Fixed32
+        | Type::Fixed64
+        | Type::Sfixed32
+        | Type::Sfixed64
+        | Type::Bool
+        | Type::Enum => true,
+        _ => false,
+    }
 }
 
 /// Based on [`google::protobuf::UnescapeCEscapeString`][1]
@@ -769,53 +897,56 @@ fn unescape_c_escape_string(s: &str) -> Vec<u8> {
         } else {
             p += 1;
             if p == len {
-                panic!("invalid c-escaped default binary value ({}): ends with '\'", s)
+                panic!(
+                    "invalid c-escaped default binary value ({}): ends with '\'",
+                    s
+                )
             }
             match src[p] {
                 b'a' => {
                     dst.push(0x07);
                     p += 1;
-                },
+                }
                 b'b' => {
                     dst.push(0x08);
                     p += 1;
-                },
+                }
                 b'f' => {
                     dst.push(0x0C);
                     p += 1;
-                },
+                }
                 b'n' => {
                     dst.push(0x0A);
                     p += 1;
-                },
+                }
                 b'r' => {
                     dst.push(0x0D);
                     p += 1;
-                },
+                }
                 b't' => {
                     dst.push(0x09);
                     p += 1;
-                },
+                }
                 b'v' => {
                     dst.push(0x0B);
                     p += 1;
-                },
+                }
                 b'\\' => {
                     dst.push(0x5C);
                     p += 1;
-                },
+                }
                 b'?' => {
                     dst.push(0x3F);
                     p += 1;
-                },
+                }
                 b'\'' => {
                     dst.push(0x27);
                     p += 1;
-                },
+                }
                 b'"' => {
                     dst.push(0x22);
                     p += 1;
-                },
+                }
                 b'0'...b'7' => {
                     eprintln!("another octal: {}, offset: {}", s, &s[p..]);
                     let mut octal = 0;
@@ -829,20 +960,27 @@ fn unescape_c_escape_string(s: &str) -> Vec<u8> {
                         }
                     }
                     dst.push(octal);
-                },
+                }
                 b'x' | b'X' => {
                     if p + 2 > len {
-                        panic!("invalid c-escaped default binary value ({}): incomplete hex value", s)
+                        panic!(
+                            "invalid c-escaped default binary value ({}): incomplete hex value",
+                            s
+                        )
                     }
-                    match u8::from_str_radix(&s[p+1..p+3], 16) {
+                    match u8::from_str_radix(&s[p + 1..p + 3], 16) {
                         Ok(b) => dst.push(b),
-                        _ => panic!("invalid c-escaped default binary value ({}): invalid hex value", &s[p..p+2]),
+                        _ => panic!(
+                            "invalid c-escaped default binary value ({}): invalid hex value",
+                            &s[p..p + 2]
+                        ),
                     }
                     p += 3;
-                },
-                _ => {
-                    panic!("invalid c-escaped default binary value ({}): invalid escape", s)
-                },
+                }
+                _ => panic!(
+                    "invalid c-escaped default binary value ({}): invalid escape",
+                    s
+                ),
             }
         }
     }
@@ -855,14 +993,22 @@ mod tests {
 
     #[test]
     fn test_unescape_c_escape_string() {
-        assert_eq!(&b"hello world"[..], &unescape_c_escape_string("hello world")[..]);
+        assert_eq!(
+            &b"hello world"[..],
+            &unescape_c_escape_string("hello world")[..]
+        );
 
         assert_eq!(&b"\0"[..], &unescape_c_escape_string(r#"\0"#)[..]);
 
-        assert_eq!(&[0o012, 0o156], &unescape_c_escape_string(r#"\012\156"#)[..]);
+        assert_eq!(
+            &[0o012, 0o156],
+            &unescape_c_escape_string(r#"\012\156"#)[..]
+        );
         assert_eq!(&[0x01, 0x02], &unescape_c_escape_string(r#"\x01\x02"#)[..]);
 
-        assert_eq!(&b"\0\x01\x07\x08\x0C\n\r\t\x0B\\\'\"\xFE"[..],
-                   &unescape_c_escape_string(r#"\0\001\a\b\f\n\r\t\v\\\'\"\xfe"#)[..]);
+        assert_eq!(
+            &b"\0\x01\x07\x08\x0C\n\r\t\x0B\\\'\"\xFE"[..],
+            &unescape_c_escape_string(r#"\0\001\a\b\f\n\r\t\v\\\'\"\xfe"#)[..]
+        );
     }
 }

--- a/prost-build/src/ident.rs
+++ b/prost-build/src/ident.rs
@@ -10,14 +10,12 @@ pub fn to_snake(s: &str) -> String {
     // Add a trailing underscore if the identifier matches a Rust keyword
     // (https://doc.rust-lang.org/grammar.html#keywords).
     match &ident[..] {
-        "abstract" | "alignof" | "as"     | "become"  | "box"   | "break"   | "const"    |
-        "continue" | "crate"   | "do"     | "else"    | "enum"  | "extern"  | "false"    |
-        "final"    | "fn"      | "for"    | "if"      | "impl"  | "in"      | "let"      |
-        "loop"     | "macro"   | "match"  | "mod"     | "move"  | "mut"     | "offsetof" |
-        "override" | "priv"    | "proc"   | "pub"     | "pure"  | "ref"     | "return"   |
-        "self"     | "sizeof"  | "static" | "struct"  | "super" | "trait"   | "true"     |
-        "type"     | "typeof"  | "unsafe" | "unsized" | "use"   | "virtual" | "where"    |
-        "while"    | "yield" => {
+        "abstract" | "alignof" | "as" | "become" | "box" | "break" | "const" | "continue"
+        | "crate" | "do" | "else" | "enum" | "extern" | "false" | "final" | "fn" | "for" | "if"
+        | "impl" | "in" | "let" | "loop" | "macro" | "match" | "mod" | "move" | "mut"
+        | "offsetof" | "override" | "priv" | "proc" | "pub" | "pure" | "ref" | "return"
+        | "self" | "sizeof" | "static" | "struct" | "super" | "trait" | "true" | "type"
+        | "typeof" | "unsafe" | "unsized" | "use" | "virtual" | "where" | "while" | "yield" => {
             ident.push('_');
         }
         _ => (),
@@ -137,7 +135,11 @@ mod tests {
         assert!(match_ident(".foo", ".foo.bar.Baz", Some("buzz")));
         assert!(match_ident(".foo.bar", ".foo.bar.Baz", Some("buzz")));
         assert!(match_ident(".foo.bar.Baz", ".foo.bar.Baz", Some("buzz")));
-        assert!(match_ident(".foo.bar.Baz.buzz", ".foo.bar.Baz", Some("buzz")));
+        assert!(match_ident(
+            ".foo.bar.Baz.buzz",
+            ".foo.bar.Baz",
+            Some("buzz")
+        ));
 
         assert!(!match_ident(".fo", ".foo.bar.Baz", Some("buzz")));
         assert!(!match_ident(".foo.", ".foo.bar.Baz", Some("buzz")));
@@ -148,7 +150,11 @@ mod tests {
         assert!(match_ident("buzz", ".foo.bar.Baz", Some("buzz")));
         assert!(match_ident("Baz.buzz", ".foo.bar.Baz", Some("buzz")));
         assert!(match_ident("bar.Baz.buzz", ".foo.bar.Baz", Some("buzz")));
-        assert!(match_ident("foo.bar.Baz.buzz", ".foo.bar.Baz", Some("buzz")));
+        assert!(match_ident(
+            "foo.bar.Baz.buzz",
+            ".foo.bar.Baz",
+            Some("buzz")
+        ));
 
         assert!(!match_ident("buz", ".foo.bar.Baz", Some("buzz")));
         assert!(!match_ident("uz", ".foo.bar.Baz", Some("buzz")));

--- a/prost-build/src/lib.rs
+++ b/prost-build/src/lib.rs
@@ -127,35 +127,19 @@ mod code_generator;
 mod ident;
 mod message_graph;
 
-use std::default;
 use std::collections::HashMap;
+use std::default;
 use std::env;
 use std::fs;
-use std::io::{
-    Error,
-    ErrorKind,
-    Read,
-    Result,
-    Write,
-};
-use std::path::{
-    Path,
-    PathBuf,
-};
+use std::io::{Error, ErrorKind, Read, Result, Write};
+use std::path::{Path, PathBuf};
 use std::process::Command;
 
 use prost::Message;
 use prost_types::{FileDescriptorProto, FileDescriptorSet};
 
-pub use ast::{
-    Comments,
-    Method,
-    Service,
-};
-use code_generator::{
-    CodeGenerator,
-    module,
-};
+pub use ast::{Comments, Method, Service};
+use code_generator::{module, CodeGenerator};
 use message_graph::MessageGraph;
 
 type Module = Vec<String>;
@@ -208,7 +192,6 @@ pub struct Config {
 }
 
 impl Config {
-
     /// Creates a new code generator configuration with default options.
     pub fn new() -> Config {
         Config::default()
@@ -263,8 +246,10 @@ impl Config {
     /// [2]: https://developers.google.com/protocol-buffers/docs/proto3#maps
     /// [3]: https://doc.rust-lang.org/std/collections/struct.HashMap.html
     pub fn btree_map<I, S>(&mut self, paths: I) -> &mut Self
-    where I: IntoIterator<Item = S>,
-          S: AsRef<str> {
+    where
+        I: IntoIterator<Item = S>,
+        S: AsRef<str>,
+    {
         self.btree_map = paths.into_iter().map(|s| s.as_ref().to_string()).collect();
         self
     }
@@ -293,9 +278,12 @@ impl Config {
     /// config.field_attribute("in", "#[serde(rename = \"in\")]");
     /// ```
     pub fn field_attribute<P, A>(&mut self, path: P, attribute: A) -> &mut Self
-    where P: AsRef<str>,
-          A: AsRef<str> {
-        self.field_attributes.push((path.as_ref().to_string(), attribute.as_ref().to_string()));
+    where
+        P: AsRef<str>,
+        A: AsRef<str>,
+    {
+        self.field_attributes
+            .push((path.as_ref().to_string(), attribute.as_ref().to_string()));
         self
     }
 
@@ -339,9 +327,12 @@ impl Config {
     /// In other words, to place an attribute on the `enum` implementing the `oneof`, the match
     /// would look like `my_messages.MyMessageType.oneofname`.
     pub fn type_attribute<P, A>(&mut self, path: P, attribute: A) -> &mut Self
-    where P: AsRef<str>,
-          A: AsRef<str> {
-        self.type_attributes.push((path.as_ref().to_string(), attribute.as_ref().to_string()));
+    where
+        P: AsRef<str>,
+        A: AsRef<str>,
+    {
+        self.type_attributes
+            .push((path.as_ref().to_string(), attribute.as_ref().to_string()));
         self
     }
 
@@ -388,10 +379,12 @@ impl Config {
     ///                                &["src"]).unwrap();
     /// }
     /// ```
-    pub fn compile_protos<P>(&mut self, protos: &[P], includes: &[P]) -> Result<()> where P: AsRef<Path> {
+    pub fn compile_protos<P>(&mut self, protos: &[P], includes: &[P]) -> Result<()>
+    where
+        P: AsRef<Path>,
+    {
         let target: PathBuf = env::var_os("OUT_DIR")
-            .ok_or_else(|| Error::new(ErrorKind::Other,
-                                      "OUT_DIR environment variable is not set"))?
+            .ok_or_else(|| Error::new(ErrorKind::Other, "OUT_DIR environment variable is not set"))?
             .into();
 
         // TODO: This should probably emit 'rerun-if-changed=PATH' directives for cargo, however
@@ -405,8 +398,9 @@ impl Config {
 
         let mut cmd = Command::new(protoc());
         cmd.arg("--include_imports")
-           .arg("--include_source_info")
-           .arg("-o").arg(&descriptor_set);
+            .arg("--include_source_info")
+            .arg("-o")
+            .arg(&descriptor_set);
 
         for include in includes {
             cmd.arg("-I").arg(include.as_ref());
@@ -422,9 +416,10 @@ impl Config {
 
         let output = cmd.output()?;
         if !output.status.success() {
-            return Err(Error::new(ErrorKind::Other,
-                                format!("protoc failed: {}",
-                                        String::from_utf8_lossy(&output.stderr))));
+            return Err(Error::new(
+                ErrorKind::Other,
+                format!("protoc failed: {}", String::from_utf8_lossy(&output.stderr)),
+            ));
         }
 
         let mut buf = Vec::new();
@@ -512,7 +507,10 @@ impl default::Default for Config {
 /// [1]: https://doc.rust-lang.org/std/macro.include.html
 /// [2]: http://doc.crates.io/build-script.html#case-study-code-generation
 /// [3]: https://developers.google.com/protocol-buffers/docs/proto3#importing-definitions
-pub fn compile_protos<P>(protos: &[P], includes: &[P]) -> Result<()> where P: AsRef<Path> {
+pub fn compile_protos<P>(protos: &[P], includes: &[P]) -> Result<()>
+where
+    P: AsRef<Path>,
+{
     Config::new().compile_protos(protos, includes)
 }
 
@@ -559,10 +557,10 @@ mod tests {
             // Generate the service methods.
             for method in service.methods {
                 method.comments.append_with_indent(1, buf);
-                buf.push_str(&format!("    fn {}({}) -> {};\n",
-                                      method.name,
-                                      method.input_type,
-                                      method.output_type));
+                buf.push_str(&format!(
+                    "    fn {}({}) -> {};\n",
+                    method.name, method.input_type, method.output_type
+                ));
             }
 
             // Close out the trait.
@@ -578,8 +576,8 @@ mod tests {
     fn smoke_test() {
         let _ = env_logger::init();
         Config::new()
-               .service_generator(Box::new(ServiceTraitGenerator))
-               .compile_protos(&["src/smoke_test.proto"], &["src"])
-               .unwrap();
+            .service_generator(Box::new(ServiceTraitGenerator))
+            .compile_protos(&["src/smoke_test.proto"], &["src"])
+            .unwrap();
     }
 }

--- a/prost-build/src/message_graph.rs
+++ b/prost-build/src/message_graph.rs
@@ -4,11 +4,7 @@ use petgraph::algo::has_path_connecting;
 use petgraph::graph::NodeIndex;
 use petgraph::Graph;
 
-use prost_types::{
-    DescriptorProto,
-    field_descriptor_proto,
-    FileDescriptorProto,
-};
+use prost_types::{field_descriptor_proto, DescriptorProto, FileDescriptorProto};
 
 /// `MessageGraph` builds a graph of messages whose edges correspond to nesting.
 /// The goal is to recognize when message types are recursively nested, so
@@ -36,11 +32,14 @@ impl MessageGraph {
     }
 
     fn get_or_insert_index(&mut self, msg_name: String) -> NodeIndex {
-        let MessageGraph { ref mut index, ref mut graph } = *self;
+        let MessageGraph {
+            ref mut index,
+            ref mut graph,
+        } = *self;
         assert_eq!(b'.', msg_name.as_bytes()[0]);
-        *index.entry(msg_name.clone()).or_insert_with(|| {
-            graph.add_node(msg_name)
-        })
+        *index
+            .entry(msg_name.clone())
+            .or_insert_with(|| graph.add_node(msg_name))
     }
 
     fn add_message(&mut self, package: &str, msg: &DescriptorProto) {
@@ -49,7 +48,8 @@ impl MessageGraph {
 
         for field in &msg.field {
             if field.type_() == field_descriptor_proto::Type::Message
-                && field.label() != field_descriptor_proto::Label::Repeated {
+                && field.label() != field_descriptor_proto::Label::Repeated
+            {
                 let field_index = self.get_or_insert_index(field.type_name.clone().unwrap());
                 self.graph.add_edge(msg_index, field_index, ());
             }

--- a/prost-types/Cargo.toml
+++ b/prost-types/Cargo.toml
@@ -14,6 +14,6 @@ doctest = false
 test = false
 
 [dependencies]
-bytes = "0.4.7"
+bytes = "0.5"
 prost-amino = { version = "0.4.0", path = ".." }
 prost-amino-derive = { version = "0.4.0", path = "../prost-amino-derive" }

--- a/prost-types/src/lib.rs
+++ b/prost-types/src/lib.rs
@@ -57,9 +57,17 @@ impl Duration {
 impl From<time::Duration> for Duration {
     fn from(duration: time::Duration) -> Duration {
         let seconds = duration.as_secs();
-        let seconds = if seconds > i64::MAX as u64 { i64::MAX } else { seconds as i64 };
+        let seconds = if seconds > i64::MAX as u64 {
+            i64::MAX
+        } else {
+            seconds as i64
+        };
         let nanos = duration.subsec_nanos();
-        let nanos = if nanos > i32::MAX as u32 { i32::MAX } else { nanos as i32 };
+        let nanos = if nanos > i32::MAX as u32 {
+            i32::MAX
+        } else {
+            nanos as i32
+        };
         let mut duration = Duration { seconds, nanos };
         duration.normalize();
         duration
@@ -73,10 +81,15 @@ impl From<Duration> for Result<time::Duration, time::Duration> {
     fn from(mut duration: Duration) -> Result<time::Duration, time::Duration> {
         duration.normalize();
         if duration.seconds >= 0 {
-            Ok(time::Duration::new(duration.seconds as u64, duration.nanos as u32))
+            Ok(time::Duration::new(
+                duration.seconds as u64,
+                duration.nanos as u32,
+            ))
         } else {
-            Err(time::Duration::new((-duration.seconds) as u64,
-                                    (-duration.nanos) as u32))
+            Err(time::Duration::new(
+                (-duration.seconds) as u64,
+                (-duration.nanos) as u32,
+            ))
         }
     }
 }
@@ -123,15 +136,18 @@ impl From<Timestamp> for Result<time::SystemTime, time::Duration> {
     fn from(mut timestamp: Timestamp) -> Result<time::SystemTime, time::Duration> {
         timestamp.normalize();
         if timestamp.seconds >= 0 {
-            Ok(time::UNIX_EPOCH + time::Duration::new(timestamp.seconds as u64,
-                                                      timestamp.nanos as u32))
+            Ok(time::UNIX_EPOCH
+                + time::Duration::new(timestamp.seconds as u64, timestamp.nanos as u32))
         } else {
             let mut duration = Duration {
                 seconds: -timestamp.seconds,
                 nanos: timestamp.nanos,
             };
             duration.normalize();
-            Err(time::Duration::new(duration.seconds as u64, duration.nanos as u32))
+            Err(time::Duration::new(
+                duration.seconds as u64,
+                duration.nanos as u32,
+            ))
         }
     }
 }

--- a/protobuf/build.rs
+++ b/protobuf/build.rs
@@ -7,6 +7,7 @@ use std::env;
 use std::fs;
 use std::path::{Path, PathBuf};
 use std::process::Command;
+use std::io::Cursor;
 
 use curl::easy::Easy;
 use flate2::bufread::GzDecoder;

--- a/protobuf/build.rs
+++ b/protobuf/build.rs
@@ -5,7 +5,6 @@ extern crate tempdir;
 
 use std::env;
 use std::fs;
-use std::io::Cursor;
 use std::path::{Path, PathBuf};
 use std::process::Command;
 

--- a/src/encoding.rs
+++ b/src/encoding.rs
@@ -8,7 +8,7 @@ use std::str;
 use std::u32;
 use std::usize;
 
-use bytes::{buf::ext::BufExt, Buf, BufMut};
+use bytes::{Buf, BufMut};
 
 use DecodeError;
 use Message;

--- a/src/encoding.rs
+++ b/src/encoding.rs
@@ -8,7 +8,7 @@ use std::str;
 use std::u32;
 use std::usize;
 
-use bytes::{Buf, BufMut};
+use bytes::{buf::ext::BufExt, Buf, BufMut};
 
 use DecodeError;
 use Message;

--- a/src/encoding.rs
+++ b/src/encoding.rs
@@ -3,15 +3,12 @@
 //! Meant to be used only from `Message` implementations.
 
 use std::cmp::min;
+use std::mem;
 use std::str;
 use std::u32;
 use std::usize;
-use std::mem;
 
-use bytes::{
-    Buf,
-    BufMut,
-};
+use bytes::{Buf, BufMut};
 
 use DecodeError;
 use Message;
@@ -54,7 +51,10 @@ where
     }
 }
 /// Decodes a LEB128-encoded variable length integer from the buffer.
-pub fn decode_varint<B>(buf: &mut B) -> Result<u64, DecodeError> where B: Buf {
+pub fn decode_varint<B>(buf: &mut B) -> Result<u64, DecodeError>
+where
+    B: Buf,
+{
     // NLL hack.
     'slow: loop {
         // Another NLL hack.
@@ -93,31 +93,71 @@ fn decode_varint_slice(bytes: &[u8]) -> Result<(u64, usize), DecodeError> {
 
     let mut b: u8;
     let mut part0: u32;
-    b = bytes[0]; part0  = u32::from(b)      ; if b < 0x80 { return Ok((u64::from(part0), 1)) };
+    b = bytes[0];
+    part0 = u32::from(b);
+    if b < 0x80 {
+        return Ok((u64::from(part0), 1));
+    };
     part0 -= 0x80;
-    b = bytes[1]; part0 += u32::from(b) <<  7; if b < 0x80 { return Ok((u64::from(part0), 2)) };
+    b = bytes[1];
+    part0 += u32::from(b) << 7;
+    if b < 0x80 {
+        return Ok((u64::from(part0), 2));
+    };
     part0 -= 0x80 << 7;
-    b = bytes[2]; part0 += u32::from(b) << 14; if b < 0x80 { return Ok((u64::from(part0), 3)) };
+    b = bytes[2];
+    part0 += u32::from(b) << 14;
+    if b < 0x80 {
+        return Ok((u64::from(part0), 3));
+    };
     part0 -= 0x80 << 14;
-    b = bytes[3]; part0 += u32::from(b) << 21; if b < 0x80 { return Ok((u64::from(part0), 4)) };
+    b = bytes[3];
+    part0 += u32::from(b) << 21;
+    if b < 0x80 {
+        return Ok((u64::from(part0), 4));
+    };
     part0 -= 0x80 << 21;
     let value = u64::from(part0);
 
     let mut part1: u32;
-    b = bytes[4]; part1  = u32::from(b)      ; if b < 0x80 { return Ok((value + (u64::from(part1) << 28), 5)) };
+    b = bytes[4];
+    part1 = u32::from(b);
+    if b < 0x80 {
+        return Ok((value + (u64::from(part1) << 28), 5));
+    };
     part1 -= 0x80;
-    b = bytes[5]; part1 += u32::from(b) <<  7; if b < 0x80 { return Ok((value + (u64::from(part1) << 28), 6)) };
+    b = bytes[5];
+    part1 += u32::from(b) << 7;
+    if b < 0x80 {
+        return Ok((value + (u64::from(part1) << 28), 6));
+    };
     part1 -= 0x80 << 7;
-    b = bytes[6]; part1 += u32::from(b) << 14; if b < 0x80 { return Ok((value + (u64::from(part1) << 28), 7)) };
+    b = bytes[6];
+    part1 += u32::from(b) << 14;
+    if b < 0x80 {
+        return Ok((value + (u64::from(part1) << 28), 7));
+    };
     part1 -= 0x80 << 14;
-    b = bytes[7]; part1 += u32::from(b) << 21; if b < 0x80 { return Ok((value + (u64::from(part1) << 28), 8)) };
+    b = bytes[7];
+    part1 += u32::from(b) << 21;
+    if b < 0x80 {
+        return Ok((value + (u64::from(part1) << 28), 8));
+    };
     part1 -= 0x80 << 21;
     let value = value + ((u64::from(part1)) << 28);
 
     let mut part2: u32;
-    b = bytes[8]; part2  = u32::from(b)      ; if b < 0x80 { return Ok((value + (u64::from(part2) << 56), 9)) };
+    b = bytes[8];
+    part2 = u32::from(b);
+    if b < 0x80 {
+        return Ok((value + (u64::from(part2) << 56), 9));
+    };
     part2 -= 0x80;
-    b = bytes[9]; part2 += u32::from(b) <<  7; if b < 0x80 { return Ok((value + (u64::from(part2) << 56), 10)) };
+    b = bytes[9];
+    part2 += u32::from(b) << 7;
+    if b < 0x80 {
+        return Ok((value + (u64::from(part2) << 56), 10));
+    };
 
     // We have overrun the maximum size of a varint (10 bytes). Assume the data is corrupt.
     Err(DecodeError::new("invalid varint"))
@@ -126,7 +166,10 @@ fn decode_varint_slice(bytes: &[u8]) -> Result<(u64, usize), DecodeError> {
 /// Decodes a LEB128-encoded variable length integer from the buffer, advancing the buffer as
 /// necessary.
 #[inline(never)]
-fn decode_varint_slow<B>(buf: &mut B) -> Result<u64, DecodeError> where B: Buf {
+fn decode_varint_slow<B>(buf: &mut B) -> Result<u64, DecodeError>
+where
+    B: Buf,
+{
     let mut value = 0;
     for count in 0..min(10, buf.remaining()) {
         let byte = buf.get_u8();
@@ -154,7 +197,7 @@ pub enum WireType {
     Varint = 0,
     SixtyFourBit = 1,
     LengthDelimited = 2,
-    ThirtyTwoBit = 5
+    ThirtyTwoBit = 5,
 }
 
 pub const MIN_TAG: u32 = 1;
@@ -169,7 +212,10 @@ impl WireType {
             1 => Ok(WireType::SixtyFourBit),
             2 => Ok(WireType::LengthDelimited),
             5 => Ok(WireType::ThirtyTwoBit),
-            _ => Err(DecodeError::new(format!("invalid wire type value: {}", val))),
+            _ => Err(DecodeError::new(format!(
+                "invalid wire type value: {}",
+                val
+            ))),
         }
     }
 }
@@ -177,7 +223,10 @@ impl WireType {
 /// Encodes a Protobuf field key, which consists of a wire type designator and
 /// the field tag.
 #[inline]
-pub fn encode_key<B>(tag: u32, wire_type: WireType, buf: &mut B) where B: BufMut {
+pub fn encode_key<B>(tag: u32, wire_type: WireType, buf: &mut B)
+where
+    B: BufMut,
+{
     debug_assert!(tag >= MIN_TAG && tag <= MAX_TAG);
     let key = (tag << 3) | wire_type as u32;
     encode_varint(u64::from(key), buf);
@@ -186,7 +235,10 @@ pub fn encode_key<B>(tag: u32, wire_type: WireType, buf: &mut B) where B: BufMut
 /// Decodes a Protobuf field key, which consists of a wire type designator and
 /// the field tag.
 #[inline]
-pub fn decode_key<B>(buf: &mut B) -> Result<(u32, WireType), DecodeError> where B: Buf {
+pub fn decode_key<B>(buf: &mut B) -> Result<(u32, WireType), DecodeError>
+where
+    B: Buf,
+{
     let key = decode_varint(buf)?;
     if key > u64::from(u32::MAX) {
         return Err(DecodeError::new(format!("invalid key value: {}", key)));
@@ -213,7 +265,10 @@ pub fn key_len(tag: u32) -> usize {
 #[inline]
 pub fn check_wire_type(expected: WireType, actual: WireType) -> Result<(), DecodeError> {
     if expected != actual {
-        return Err(DecodeError::new(format!("invalid wire type: {:?} (expected {:?})", actual, expected)));
+        return Err(DecodeError::new(format!(
+            "invalid wire type: {:?} (expected {:?})",
+            actual, expected
+        )));
     }
     Ok(())
 }
@@ -223,25 +278,29 @@ pub fn check_wire_type(expected: WireType, actual: WireType) -> Result<(), Decod
 pub fn merge_loop<T, M, B>(value: &mut T, buf: &mut B, mut merge: M) -> Result<(), DecodeError>
 where
     M: FnMut(&mut T, &mut B) -> Result<(), DecodeError>,
-    B: Buf {
-        let len = decode_varint(buf)?;
-        let remaining = buf.remaining();
-        if len > remaining as u64 {
-            return Err(DecodeError::new("buffer underflow"))
-        }
+    B: Buf,
+{
+    let len = decode_varint(buf)?;
+    let remaining = buf.remaining();
+    if len > remaining as u64 {
+        return Err(DecodeError::new("buffer underflow"));
+    }
 
-        let limit = remaining - len as usize;
-        while buf.remaining() > limit {
-            merge(value, buf)?;
-        }
+    let limit = remaining - len as usize;
+    while buf.remaining() > limit {
+        merge(value, buf)?;
+    }
 
-        if buf.remaining() != limit {
-            return Err(DecodeError::new("delimited length exceeded"))
-        }
-        Ok(())
+    if buf.remaining() != limit {
+        return Err(DecodeError::new("delimited length exceeded"));
+    }
+    Ok(())
 }
 
-pub fn skip_field<B>(wire_type: WireType, buf: &mut B) -> Result<(), DecodeError> where B: Buf {
+pub fn skip_field<B>(wire_type: WireType, buf: &mut B) -> Result<(), DecodeError>
+where
+    B: Buf,
+{
     let len = match wire_type {
         WireType::Varint => decode_varint(buf).map(|_| 0)?,
         WireType::ThirtyTwoBit => 4,
@@ -259,13 +318,16 @@ pub fn skip_field<B>(wire_type: WireType, buf: &mut B) -> Result<(), DecodeError
 
 /// Helper macro which emits an `encode_repeated` function for the type.
 macro_rules! encode_repeated {
-    ($ty:ty) => (
-         pub fn encode_repeated<B>(tag: u32, values: &[$ty], buf: &mut B) where B: BufMut {
-             for value in values {
-                 encode(tag, value, buf);
-             }
-         }
-    )
+    ($ty:ty) => {
+        pub fn encode_repeated<B>(tag: u32, values: &[$ty], buf: &mut B)
+        where
+            B: BufMut,
+        {
+            for value in values {
+                encode(tag, value, buf);
+            }
+        }
+    };
 }
 
 /// Helper macro which emits a `merge_repeated_numeric` function for the numeric type.
@@ -273,11 +335,15 @@ macro_rules! merge_repeated_numeric {
     ($ty:ty,
      $wire_type:expr,
      $merge:ident,
-     $merge_repeated:ident) => (
-        pub fn $merge_repeated<B>(wire_type: WireType,
-                                  values: &mut Vec<$ty>,
-                                  buf: &mut B)
-                                  -> Result<(), DecodeError> where B: Buf {
+     $merge_repeated:ident) => {
+        pub fn $merge_repeated<B>(
+            wire_type: WireType,
+            values: &mut Vec<$ty>,
+            buf: &mut B,
+        ) -> Result<(), DecodeError>
+        where
+            B: Buf,
+        {
             if wire_type == WireType::LengthDelimited {
                 // Packed.
                 merge_loop(values, buf, |values, buf| {
@@ -295,7 +361,7 @@ macro_rules! merge_repeated_numeric {
                 Ok(())
             }
         }
-    )
+    };
 }
 
 /// Macro which emits a module containing a set of encoding functions for a
@@ -438,23 +504,37 @@ macro_rules! fixed_width {
      $wire_type:expr,
      $proto_ty:ident,
      $put:ident,
-     $get:ident) => (
+     $get:ident) => {
         pub mod $proto_ty {
-            use ::encoding::*;
+            use encoding::*;
 
-            pub fn encode<B>(tag: u32, value: &$ty, buf: &mut B) where B: BufMut {
+            pub fn encode<B>(tag: u32, value: &$ty, buf: &mut B)
+            where
+                B: BufMut,
+            {
                 encode_key(tag, $wire_type, buf);
                 buf.$put(*value);
             }
 
-            pub fn encode_with_prefix<B>(_tag: u32,
-                                         _value: &$ty,
-                                         _amino_prefix: &Vec<u8>,
-                                         _buf: &mut B) where B: BufMut {
+            pub fn encode_with_prefix<B>(
+                _tag: u32,
+                _value: &$ty,
+                _amino_prefix: &Vec<u8>,
+                _buf: &mut B,
+            ) where
+                B: BufMut,
+            {
                 panic!("amino prefix not implemented for type");
             }
 
-            pub fn merge<B>(wire_type: WireType, value: &mut $ty, buf: &mut B) -> Result<(), DecodeError> where B: Buf {
+            pub fn merge<B>(
+                wire_type: WireType,
+                value: &mut $ty,
+                buf: &mut B,
+            ) -> Result<(), DecodeError>
+            where
+                B: Buf,
+            {
                 check_wire_type($wire_type, wire_type)?;
                 if buf.remaining() < $width {
                     return Err(DecodeError::new("buffer underflow"));
@@ -465,8 +545,13 @@ macro_rules! fixed_width {
 
             encode_repeated!($ty);
 
-            pub fn encode_packed<B>(tag: u32, values: &[$ty], buf: &mut B) where B: BufMut {
-                if values.is_empty() { return; }
+            pub fn encode_packed<B>(tag: u32, values: &[$ty], buf: &mut B)
+            where
+                B: BufMut,
+            {
+                if values.is_empty() {
+                    return;
+                }
 
                 encode_key(tag, WireType::LengthDelimited, buf);
                 let len = values.len() as u64 * $width;
@@ -503,11 +588,8 @@ macro_rules! fixed_width {
             mod test {
                 use quickcheck::TestResult;
 
+                use super::super::test::{check_collection_type, check_type};
                 use super::*;
-                use super::super::test::{
-                    check_collection_type,
-                    check_type,
-                };
 
                 quickcheck! {
                     fn check(value: $ty, tag: u32) -> TestResult {
@@ -527,95 +609,143 @@ macro_rules! fixed_width {
                 }
             }
         }
-    );
+    };
 }
-fixed_width!(f32, 4, WireType::ThirtyTwoBit, float, put_f32_le, get_f32_le);
-fixed_width!(f64, 8, WireType::SixtyFourBit, double, put_f64_le, get_f64_le);
-fixed_width!(u32, 4, WireType::ThirtyTwoBit, fixed32, put_u32_le, get_u32_le);
-fixed_width!(u64, 8, WireType::SixtyFourBit, fixed64, put_u64_le, get_u64_le);
-fixed_width!(i32, 4, WireType::ThirtyTwoBit, sfixed32, put_i32_le, get_i32_le);
-fixed_width!(i64, 8, WireType::SixtyFourBit, sfixed64, put_i64_le, get_i64_le);
+fixed_width!(
+    f32,
+    4,
+    WireType::ThirtyTwoBit,
+    float,
+    put_f32_le,
+    get_f32_le
+);
+fixed_width!(
+    f64,
+    8,
+    WireType::SixtyFourBit,
+    double,
+    put_f64_le,
+    get_f64_le
+);
+fixed_width!(
+    u32,
+    4,
+    WireType::ThirtyTwoBit,
+    fixed32,
+    put_u32_le,
+    get_u32_le
+);
+fixed_width!(
+    u64,
+    8,
+    WireType::SixtyFourBit,
+    fixed64,
+    put_u64_le,
+    get_u64_le
+);
+fixed_width!(
+    i32,
+    4,
+    WireType::ThirtyTwoBit,
+    sfixed32,
+    put_i32_le,
+    get_i32_le
+);
+fixed_width!(
+    i64,
+    8,
+    WireType::SixtyFourBit,
+    sfixed64,
+    put_i64_le,
+    get_i64_le
+);
 
 /// Macro which emits encoding functions for a length-delimited type.
 macro_rules! length_delimited {
-    ($ty:ty) => (
-
+    ($ty:ty) => {
         encode_repeated!($ty);
 
-         pub fn merge_repeated<B>(wire_type: WireType, values: &mut Vec<$ty>, buf: &mut B) -> Result<(), DecodeError> where B: Buf {
-                check_wire_type(WireType::LengthDelimited, wire_type)?;
-                let mut value = Default::default();
-                merge(wire_type, &mut value, buf)?;
-                values.push(value);
-                Ok(())
-         }
+        pub fn merge_repeated<B>(
+            wire_type: WireType,
+            values: &mut Vec<$ty>,
+            buf: &mut B,
+        ) -> Result<(), DecodeError>
+        where
+            B: Buf,
+        {
+            check_wire_type(WireType::LengthDelimited, wire_type)?;
+            let mut value = Default::default();
+            merge(wire_type, &mut value, buf)?;
+            values.push(value);
+            Ok(())
+        }
 
-         #[inline]
-         pub fn encoded_len(tag: u32, value: &$ty) -> usize {
-             key_len(tag) + encoded_len_varint(value.len() as u64) + value.len()
-         }
+        #[inline]
+        pub fn encoded_len(tag: u32, value: &$ty) -> usize {
+            key_len(tag) + encoded_len_varint(value.len() as u64) + value.len()
+        }
 
-         #[inline]
-         pub fn encoded_len_repeated(tag: u32, values: &[$ty]) -> usize {
-             key_len(tag) * values.len() + values.iter().map(|value| {
-                 encoded_len_varint(value.len() as u64) + value.len()
-             }).sum::<usize>()
-         }
+        #[inline]
+        pub fn encoded_len_repeated(tag: u32, values: &[$ty]) -> usize {
+            key_len(tag) * values.len()
+                + values
+                    .iter()
+                    .map(|value| encoded_len_varint(value.len() as u64) + value.len())
+                    .sum::<usize>()
+        }
 
-         #[cfg(test)]
-         mod test {
+        #[cfg(test)]
+        mod test {
             use quickcheck::TestResult;
 
+            use super::super::test::{check_collection_type, check_type};
             use super::*;
-            use super::super::test::{
-                check_collection_type,
-                check_type,
-            };
 
-             quickcheck! {
-                 fn check(value: $ty, tag: u32) -> TestResult {
-                     super::test::check_type(value, tag, WireType::LengthDelimited,
-                                             encode, merge, encoded_len)
-                 }
-                 fn check_repeated(value: Vec<$ty>, tag: u32) -> TestResult {
-                     super::test::check_collection_type(value, tag, WireType::LengthDelimited,
-                                                        encode_repeated, merge_repeated,
-                                                        encoded_len_repeated)
-                 }
-             }
-         }
-    )
+            quickcheck! {
+                fn check(value: $ty, tag: u32) -> TestResult {
+                    super::test::check_type(value, tag, WireType::LengthDelimited,
+                                            encode, merge, encoded_len)
+                }
+                fn check_repeated(value: Vec<$ty>, tag: u32) -> TestResult {
+                    super::test::check_collection_type(value, tag, WireType::LengthDelimited,
+                                                       encode_repeated, merge_repeated,
+                                                       encoded_len_repeated)
+                }
+            }
+        }
+    };
 }
 
 pub mod string {
     use super::*;
 
-    pub fn encode<B>(tag: u32,
-                     value: &String,
-                     buf: &mut B) where B: BufMut {
+    pub fn encode<B>(tag: u32, value: &String, buf: &mut B)
+    where
+        B: BufMut,
+    {
         encode_key(tag, WireType::LengthDelimited, buf);
         encode_varint(value.len() as u64, buf);
         buf.put_slice(value.as_bytes());
     }
 
-    pub fn encode_with_prefix<B>(_tag: u32,
-                     _value: &String,
-                     _amino_prefix: Vec<u8>,
-                     _buf: &mut B) where B: BufMut {
+    pub fn encode_with_prefix<B>(_tag: u32, _value: &String, _amino_prefix: Vec<u8>, _buf: &mut B)
+    where
+        B: BufMut,
+    {
         panic!("amino prefix not implemented for type");
     }
 
-    pub fn merge<B>(wire_type: WireType,
-                    value: &mut String,
-                    buf: &mut B) -> Result<(), DecodeError> where B: Buf {
+    pub fn merge<B>(wire_type: WireType, value: &mut String, buf: &mut B) -> Result<(), DecodeError>
+    where
+        B: Buf,
+    {
         unsafe {
             // String::as_mut_vec is unsafe because it doesn't check that the bytes
             // inserted into it the resulting vec are valid UTF-8. We check
             // explicitly in order to ensure this is safe.
             super::bytes::merge(wire_type, value.as_mut_vec(), buf)?;
-            str::from_utf8(value.as_bytes()).map_err(|_| {
-                DecodeError::new("invalid string value: data is not UTF-8 encoded")
-            })?;
+            str::from_utf8(value.as_bytes())
+                .map_err(|_| DecodeError::new("invalid string value: data is not UTF-8 encoded"))?;
         }
         Ok(())
     }
@@ -626,22 +756,35 @@ pub mod string {
 pub mod bytes {
     use super::*;
 
-    pub fn encode<B>(tag: u32, value: &Vec<u8>, buf: &mut B) where B: BufMut {
+    pub fn encode<B>(tag: u32, value: &Vec<u8>, buf: &mut B)
+    where
+        B: BufMut,
+    {
         encode_key(tag, WireType::LengthDelimited, buf);
         encode_varint(value.len() as u64, buf);
         buf.put_slice(value);
     }
 
-    pub fn encode_with_prefix<B>(tag: u32,value: &Vec<u8>, amino_prefix: &Vec<u8>, buf: &mut B) where B: BufMut {
+    pub fn encode_with_prefix<B>(tag: u32, value: &Vec<u8>, amino_prefix: &Vec<u8>, buf: &mut B)
+    where
+        B: BufMut,
+    {
         encode_key(tag, WireType::LengthDelimited, buf);
         // length delim: the actual bytes + 4 prefix bytes + 1 additional length delim.
-        encode_varint((value.len()+amino_prefix.len()+1) as u64, buf);
+        encode_varint((value.len() + amino_prefix.len() + 1) as u64, buf);
         buf.put_slice(amino_prefix);
         encode_varint((value.len()) as u64, buf);
         buf.put_slice(value);
     }
 
-    pub fn merge<B>(wire_type: WireType, value: &mut Vec<u8>, buf: &mut B) -> Result<(), DecodeError> where B: Buf {
+    pub fn merge<B>(
+        wire_type: WireType,
+        value: &mut Vec<u8>,
+        buf: &mut B,
+    ) -> Result<(), DecodeError>
+    where
+        B: Buf,
+    {
         check_wire_type(WireType::LengthDelimited, wire_type)?;
         let len = decode_varint(buf)?;
         if len > buf.remaining() as u64 {
@@ -664,9 +807,17 @@ pub mod bytes {
         Ok(())
     }
 
-    pub fn merge_with_prefix<B>(wire_type: WireType, value: &mut Vec<u8>, amino_prefix: &Vec<u8>, buf: &mut B) -> Result<(), DecodeError> where B: Buf {
+    pub fn merge_with_prefix<B>(
+        wire_type: WireType,
+        value: &mut Vec<u8>,
+        amino_prefix: &Vec<u8>,
+        buf: &mut B,
+    ) -> Result<(), DecodeError>
+    where
+        B: Buf,
+    {
         // skip 4+1 bytes (or amino_prefix + length delimiter)
-        buf.advance(amino_prefix.len()+1);
+        buf.advance(amino_prefix.len() + 1);
         merge(wire_type, value, buf)
     }
 
@@ -677,40 +828,54 @@ pub mod message {
     use super::*;
 
     pub fn encode<M, B>(tag: u32, msg: &M, buf: &mut B)
-    where M: Message,
-          B: BufMut {
+    where
+        M: Message,
+        B: BufMut,
+    {
         encode_key(tag, WireType::LengthDelimited, buf);
         encode_varint(msg.encoded_len() as u64, buf);
         msg.encode_raw(buf);
     }
 
     pub fn encode_with_prefix<M, B>(tag: u32, msg: &M, amino_prefix: &Vec<u8>, buf: &mut B)
-        where M: Message,
-              B: BufMut {
+    where
+        M: Message,
+        B: BufMut,
+    {
         encode_key(tag, WireType::LengthDelimited, buf);
-        encode_varint((msg.encoded_len()+amino_prefix.len()-1) as u64, buf);
+        encode_varint((msg.encoded_len() + amino_prefix.len() - 1) as u64, buf);
         buf.put(amino_prefix.as_ref());
-        encode_varint((msg.encoded_len()-2) as u64, buf);
+        encode_varint((msg.encoded_len() - 2) as u64, buf);
     }
 
     pub fn merge<M, B>(wire_type: WireType, msg: &mut M, buf: &mut B) -> Result<(), DecodeError>
-    where M: Message,
-          B: Buf {
+    where
+        M: Message,
+        B: Buf,
+    {
         check_wire_type(WireType::LengthDelimited, wire_type)?;
         merge_loop(msg, buf, M::merge_field)
     }
 
     pub fn encode_repeated<M, B>(tag: u32, messages: &[M], buf: &mut B)
-    where M: Message,
-          B: BufMut {
+    where
+        M: Message,
+        B: BufMut,
+    {
         for msg in messages {
             encode(tag, msg, buf);
         }
     }
 
-    pub fn merge_repeated<M, B>(wire_type: WireType, messages: &mut Vec<M>, buf: &mut B) -> Result<(), DecodeError>
-    where M: Message + Default,
-          B: Buf {
+    pub fn merge_repeated<M, B>(
+        wire_type: WireType,
+        messages: &mut Vec<M>,
+        buf: &mut B,
+    ) -> Result<(), DecodeError>
+    where
+        M: Message + Default,
+        B: Buf,
+    {
         check_wire_type(WireType::LengthDelimited, wire_type)?;
         let mut msg = M::default();
         merge(WireType::LengthDelimited, &mut msg, buf)?;
@@ -719,102 +884,128 @@ pub mod message {
     }
 
     #[inline]
-    pub fn encoded_len<M>(tag: u32, msg: &M) -> usize where M: Message {
+    pub fn encoded_len<M>(tag: u32, msg: &M) -> usize
+    where
+        M: Message,
+    {
         let len = msg.encoded_len();
         key_len(tag) + encoded_len_varint(len as u64) + msg.encoded_len()
     }
 
     #[inline]
-    pub fn encoded_len_repeated<M>(tag: u32, messages: &[M]) -> usize where M: Message {
+    pub fn encoded_len_repeated<M>(tag: u32, messages: &[M]) -> usize
+    where
+        M: Message,
+    {
         key_len(tag) * messages.len()
-            + messages.iter()
-                      .map(Message::encoded_len)
-                      .map(|len| len + encoded_len_varint(len as u64))
-                      .sum::<usize>()
+            + messages
+                .iter()
+                .map(Message::encoded_len)
+                .map(|len| len + encoded_len_varint(len as u64))
+                .sum::<usize>()
     }
 }
 
 /// Rust doesn't have a `Map` trait, so macros are currently the best way to be
 /// generic over `HashMap` and `BTreeMap`.
 macro_rules! map {
-    ($map_ty:ident) => (
+    ($map_ty:ident) => {
         use std::collections::$map_ty;
         use std::hash::Hash;
 
-        use ::encoding::*;
+        use encoding::*;
 
         /// Generic protobuf map encode function.
-        pub fn encode<K, V, B, KE, KL, VE, VL>(key_encode: KE,
-                                               key_encoded_len: KL,
-                                               val_encode: VE,
-                                               val_encoded_len: VL,
-                                               tag: u32,
-                                               values: &$map_ty<K, V>,
-                                               buf: &mut B)
-        where K: Default + Eq + Hash + Ord,
-              V: Default + PartialEq,
-              B: BufMut,
-              KE: Fn(u32, &K, &mut B),
-              KL: Fn(u32, &K) -> usize,
-              VE: Fn(u32, &V, &mut B),
-              VL: Fn(u32, &V) -> usize {
-            encode_with_default(key_encode, key_encoded_len, val_encode, val_encoded_len,
-                                &V::default(), tag, values, buf)
+        pub fn encode<K, V, B, KE, KL, VE, VL>(
+            key_encode: KE,
+            key_encoded_len: KL,
+            val_encode: VE,
+            val_encoded_len: VL,
+            tag: u32,
+            values: &$map_ty<K, V>,
+            buf: &mut B,
+        ) where
+            K: Default + Eq + Hash + Ord,
+            V: Default + PartialEq,
+            B: BufMut,
+            KE: Fn(u32, &K, &mut B),
+            KL: Fn(u32, &K) -> usize,
+            VE: Fn(u32, &V, &mut B),
+            VL: Fn(u32, &V) -> usize,
+        {
+            encode_with_default(
+                key_encode,
+                key_encoded_len,
+                val_encode,
+                val_encoded_len,
+                &V::default(),
+                tag,
+                values,
+                buf,
+            )
         }
 
         /// Generic protobuf map merge function.
-        pub fn merge<K, V, B, KM, VM>(key_merge: KM,
-                                      val_merge: VM,
-                                      values: &mut $map_ty<K, V>,
-                                      buf: &mut B)
-                                      -> Result<(), DecodeError>
-        where K: Default + Eq + Hash + Ord,
-              V: Default,
-              B: Buf,
-              KM: Fn(WireType, &mut K, &mut B) -> Result<(), DecodeError>,
-              VM: Fn(WireType, &mut V, &mut B) -> Result<(), DecodeError> {
+        pub fn merge<K, V, B, KM, VM>(
+            key_merge: KM,
+            val_merge: VM,
+            values: &mut $map_ty<K, V>,
+            buf: &mut B,
+        ) -> Result<(), DecodeError>
+        where
+            K: Default + Eq + Hash + Ord,
+            V: Default,
+            B: Buf,
+            KM: Fn(WireType, &mut K, &mut B) -> Result<(), DecodeError>,
+            VM: Fn(WireType, &mut V, &mut B) -> Result<(), DecodeError>,
+        {
             merge_with_default(key_merge, val_merge, V::default(), values, buf)
         }
 
         /// Generic protobuf map encode function.
-        pub fn encoded_len<K, V, KL, VL>(key_encoded_len: KL,
-                                         val_encoded_len: VL,
-                                         tag: u32,
-                                         values: &$map_ty<K, V>)
-                                         -> usize
-        where K: Default + Eq + Hash + Ord,
-              V: Default + PartialEq,
-              KL: Fn(u32, &K) -> usize,
-              VL: Fn(u32, &V) -> usize {
-            encoded_len_with_default(key_encoded_len, val_encoded_len, &V::default(),
-                                        tag, values)
+        pub fn encoded_len<K, V, KL, VL>(
+            key_encoded_len: KL,
+            val_encoded_len: VL,
+            tag: u32,
+            values: &$map_ty<K, V>,
+        ) -> usize
+        where
+            K: Default + Eq + Hash + Ord,
+            V: Default + PartialEq,
+            KL: Fn(u32, &K) -> usize,
+            VL: Fn(u32, &V) -> usize,
+        {
+            encoded_len_with_default(key_encoded_len, val_encoded_len, &V::default(), tag, values)
         }
 
         /// Generic protobuf map encode function with an overriden value default.
         ///
         /// This is necessary because enumeration values can have a default value other
         /// than 0 in proto2.
-        pub fn encode_with_default<K, V, B, KE, KL, VE, VL>(key_encode: KE,
-                                                            key_encoded_len: KL,
-                                                            val_encode: VE,
-                                                            val_encoded_len: VL,
-                                                            val_default: &V,
-                                                            tag: u32,
-                                                            values: &$map_ty<K, V>,
-                                                            buf: &mut B)
-        where K: Default + Eq + Hash + Ord,
-              V: PartialEq,
-              B: BufMut,
-              KE: Fn(u32, &K, &mut B),
-              KL: Fn(u32, &K) -> usize,
-              VE: Fn(u32, &V, &mut B),
-              VL: Fn(u32, &V) -> usize {
+        pub fn encode_with_default<K, V, B, KE, KL, VE, VL>(
+            key_encode: KE,
+            key_encoded_len: KL,
+            val_encode: VE,
+            val_encoded_len: VL,
+            val_default: &V,
+            tag: u32,
+            values: &$map_ty<K, V>,
+            buf: &mut B,
+        ) where
+            K: Default + Eq + Hash + Ord,
+            V: PartialEq,
+            B: BufMut,
+            KE: Fn(u32, &K, &mut B),
+            KL: Fn(u32, &K) -> usize,
+            VE: Fn(u32, &V, &mut B),
+            VL: Fn(u32, &V) -> usize,
+        {
             for (key, val) in values.iter() {
                 let skip_key = key == &K::default();
                 let skip_val = val == val_default;
 
-                let len = (if skip_key { 0 } else { key_encoded_len(1, key) }) +
-                        (if skip_val { 0 } else { val_encoded_len(2, val) });
+                let len = (if skip_key { 0 } else { key_encoded_len(1, key) })
+                    + (if skip_val { 0 } else { val_encoded_len(2, val) });
 
                 encode_key(tag, WireType::LengthDelimited, buf);
                 encode_varint(len as u64, buf);
@@ -831,27 +1022,33 @@ macro_rules! map {
         ///
         /// This is necessary because enumeration values can have a default value other
         /// than 0 in proto2.
-        pub fn merge_with_default<K, V, B, KM, VM>(key_merge: KM,
-                                                   val_merge: VM,
-                                                   val_default: V,
-                                                   values: &mut $map_ty<K, V>,
-                                                   buf: &mut B)
-                                                   -> Result<(), DecodeError>
-        where K: Default + Eq + Hash + Ord,
-              B: Buf,
-              KM: Fn(WireType, &mut K, &mut B) -> Result<(), DecodeError>,
-              VM: Fn(WireType, &mut V, &mut B) -> Result<(), DecodeError> {
-
+        pub fn merge_with_default<K, V, B, KM, VM>(
+            key_merge: KM,
+            val_merge: VM,
+            val_default: V,
+            values: &mut $map_ty<K, V>,
+            buf: &mut B,
+        ) -> Result<(), DecodeError>
+        where
+            K: Default + Eq + Hash + Ord,
+            B: Buf,
+            KM: Fn(WireType, &mut K, &mut B) -> Result<(), DecodeError>,
+            VM: Fn(WireType, &mut V, &mut B) -> Result<(), DecodeError>,
+        {
             let mut key = Default::default();
             let mut val = val_default;
-            merge_loop(&mut (&mut key, &mut val), buf, |&mut (ref mut key, ref mut val), buf| {
-                let (tag, wire_type) = decode_key(buf)?;
-                match tag {
-                    1 => key_merge(wire_type, key, buf),
-                    2 => val_merge(wire_type, val, buf),
-                    _ => skip_field(wire_type, buf),
-                }
-            })?;
+            merge_loop(
+                &mut (&mut key, &mut val),
+                buf,
+                |&mut (ref mut key, ref mut val), buf| {
+                    let (tag, wire_type) = decode_key(buf)?;
+                    match tag {
+                        1 => key_merge(wire_type, key, buf),
+                        2 => val_merge(wire_type, val, buf),
+                        _ => skip_field(wire_type, buf),
+                    }
+                },
+            )?;
             values.insert(key, val);
 
             Ok(())
@@ -861,23 +1058,37 @@ macro_rules! map {
         ///
         /// This is necessary because enumeration values can have a default value other
         /// than 0 in proto2.
-        pub fn encoded_len_with_default<K, V, KL, VL>(key_encoded_len: KL,
-                                                      val_encoded_len: VL,
-                                                      val_default: &V,
-                                                      tag: u32,
-                                                      values: &$map_ty<K, V>)
-                                                      -> usize
-        where K: Default + Eq + Hash + Ord,
-              V: PartialEq,
-              KL: Fn(u32, &K) -> usize,
-              VL: Fn(u32, &V) -> usize {
-            key_len(tag) * values.len() + values.iter().map(|(key, val)| {
-                let len = (if key == &K::default() { 0 } else { key_encoded_len(1, key) })
-                        + (if val == val_default { 0 } else { val_encoded_len(2, val) });
-                encoded_len_varint(len as u64) + len
-            }).sum::<usize>()
+        pub fn encoded_len_with_default<K, V, KL, VL>(
+            key_encoded_len: KL,
+            val_encoded_len: VL,
+            val_default: &V,
+            tag: u32,
+            values: &$map_ty<K, V>,
+        ) -> usize
+        where
+            K: Default + Eq + Hash + Ord,
+            V: PartialEq,
+            KL: Fn(u32, &K) -> usize,
+            VL: Fn(u32, &V) -> usize,
+        {
+            key_len(tag) * values.len()
+                + values
+                    .iter()
+                    .map(|(key, val)| {
+                        let len = (if key == &K::default() {
+                            0
+                        } else {
+                            key_encoded_len(1, key)
+                        }) + (if val == val_default {
+                            0
+                        } else {
+                            val_encoded_len(2, val)
+                        });
+                        encoded_len_varint(len as u64) + len
+                    })
+                    .sum::<usize>()
         }
-    )
+    };
 }
 
 pub mod hash_map {
@@ -897,20 +1108,22 @@ mod test {
     use bytes::{Bytes, BytesMut};
     use quickcheck::TestResult;
 
-    use ::encoding::*;
+    use encoding::*;
 
-    pub fn check_type<T, B>(value: T,
-                            tag: u32,
-                            wire_type: WireType,
-                            encode: fn(u32, &B, &mut BytesMut),
-                            merge: fn(WireType, &mut T, &mut Bytes) -> Result<(), DecodeError>,
-                            encoded_len: fn(u32, &B) -> usize)
-                            -> TestResult
-    where T: Debug + Default + PartialEq + Borrow<B>,
-          B: ?Sized {
-
+    pub fn check_type<T, B>(
+        value: T,
+        tag: u32,
+        wire_type: WireType,
+        encode: fn(u32, &B, &mut BytesMut),
+        merge: fn(WireType, &mut T, &mut Bytes) -> Result<(), DecodeError>,
+        encoded_len: fn(u32, &B) -> usize,
+    ) -> TestResult
+    where
+        T: Debug + Default + PartialEq + Borrow<B>,
+        B: ?Sized,
+    {
         if tag > MAX_TAG || tag < MIN_TAG {
-            return TestResult::discard()
+            return TestResult::discard();
         }
 
         let expected_len = encoded_len(tag, value.borrow());
@@ -921,8 +1134,11 @@ mod test {
         let mut buf = buf.freeze();
 
         if buf.remaining() != expected_len {
-            return TestResult::error(format!("encoded_len wrong; expected: {}, actual: {}",
-                                             expected_len, buf.remaining()));
+            return TestResult::error(format!(
+                "encoded_len wrong; expected: {}, actual: {}",
+                expected_len,
+                buf.remaining()
+            ));
         }
 
         if !buf.has_remaining() {
@@ -936,28 +1152,34 @@ mod test {
         };
 
         if tag != decoded_tag {
-            return TestResult::error(
-                format!("decoded tag does not match; expected: {}, actual: {}",
-                        tag, decoded_tag));
+            return TestResult::error(format!(
+                "decoded tag does not match; expected: {}, actual: {}",
+                tag, decoded_tag
+            ));
         }
 
         if wire_type != decoded_wire_type {
-            return TestResult::error(
-                format!("decoded wire type does not match; expected: {:?}, actual: {:?}",
-                        wire_type, decoded_wire_type));
+            return TestResult::error(format!(
+                "decoded wire type does not match; expected: {:?}, actual: {:?}",
+                wire_type, decoded_wire_type
+            ));
         }
 
         match wire_type {
             WireType::SixtyFourBit if buf.remaining() != 8 => {
-                return TestResult::error(
-                    format!("64bit wire type illegal remaining: {}, tag: {}",
-                            buf.remaining(), tag));
-            },
+                return TestResult::error(format!(
+                    "64bit wire type illegal remaining: {}, tag: {}",
+                    buf.remaining(),
+                    tag
+                ));
+            }
             WireType::ThirtyTwoBit if buf.remaining() != 4 => {
-                return TestResult::error(
-                    format!("32bit wire type illegal remaining: {}, tag: {}",
-                            buf.remaining(), tag));
-            },
+                return TestResult::error(format!(
+                    "32bit wire type illegal remaining: {}, tag: {}",
+                    buf.remaining(),
+                    tag
+                ));
+            }
             _ => (),
         }
 
@@ -967,8 +1189,10 @@ mod test {
         };
 
         if buf.has_remaining() {
-            return TestResult::error(format!("expected buffer to be empty, remaining: {}",
-                                             buf.remaining()));
+            return TestResult::error(format!(
+                "expected buffer to be empty, remaining: {}",
+                buf.remaining()
+            ));
         }
 
         if value == roundtrip_value {
@@ -978,21 +1202,23 @@ mod test {
         }
     }
 
-    pub fn check_collection_type<T, B, E, M, L>(value: T,
-                                                tag: u32,
-                                                wire_type: WireType,
-                                                encode: E,
-                                                mut merge: M,
-                                                encoded_len: L)
-                                                -> TestResult
-    where T: Debug + Default + PartialEq + Borrow<B>,
-          B: ?Sized,
-          E: FnOnce(u32, &B, &mut BytesMut),
-          M: FnMut(WireType, &mut T, &mut Bytes) -> Result<(), DecodeError>,
-          L: FnOnce(u32, &B) -> usize {
-
+    pub fn check_collection_type<T, B, E, M, L>(
+        value: T,
+        tag: u32,
+        wire_type: WireType,
+        encode: E,
+        mut merge: M,
+        encoded_len: L,
+    ) -> TestResult
+    where
+        T: Debug + Default + PartialEq + Borrow<B>,
+        B: ?Sized,
+        E: FnOnce(u32, &B, &mut BytesMut),
+        M: FnMut(WireType, &mut T, &mut Bytes) -> Result<(), DecodeError>,
+        L: FnOnce(u32, &B) -> usize,
+    {
         if tag > MAX_TAG || tag < MIN_TAG {
-            return TestResult::discard()
+            return TestResult::discard();
         }
 
         let expected_len = encoded_len(tag, value.borrow());
@@ -1003,28 +1229,32 @@ mod test {
         let mut buf = buf.freeze();
 
         if buf.remaining() != expected_len {
-            return TestResult::error(format!("encoded_len wrong; expected: {}, actual: {}",
-                                             expected_len, buf.remaining()));
+            return TestResult::error(format!(
+                "encoded_len wrong; expected: {}, actual: {}",
+                expected_len,
+                buf.remaining()
+            ));
         }
 
         let mut roundtrip_value = Default::default();
         while buf.has_remaining() {
-
             let (decoded_tag, decoded_wire_type) = match decode_key(&mut buf) {
                 Ok(key) => key,
                 Err(error) => return TestResult::error(format!("{:?}", error)),
             };
 
             if tag != decoded_tag {
-                return TestResult::error(
-                    format!("decoded tag does not match; expected: {}, actual: {}",
-                            tag, decoded_tag));
+                return TestResult::error(format!(
+                    "decoded tag does not match; expected: {}, actual: {}",
+                    tag, decoded_tag
+                ));
             }
 
             if wire_type != decoded_wire_type {
-                return TestResult::error(
-                    format!("decoded wire type does not match; expected: {:?}, actual: {:?}",
-                            wire_type, decoded_wire_type));
+                return TestResult::error(format!(
+                    "decoded wire type does not match; expected: {:?}, actual: {:?}",
+                    wire_type, decoded_wire_type
+                ));
             }
 
             if let Err(error) = merge(wire_type, &mut roundtrip_value, &mut buf) {
@@ -1083,16 +1313,37 @@ mod test {
         check(2u64.pow(42) - 1, &[0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0x7F]);
         check(2u64.pow(42), &[0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x01]);
 
-        check(2u64.pow(49) - 1, &[0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0x7F]);
-        check(2u64.pow(49), &[0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x01]);
+        check(
+            2u64.pow(49) - 1,
+            &[0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0x7F],
+        );
+        check(
+            2u64.pow(49),
+            &[0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x01],
+        );
 
-        check(2u64.pow(56) - 1, &[0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0x7F]);
-        check(2u64.pow(56), &[0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x01]);
+        check(
+            2u64.pow(56) - 1,
+            &[0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0x7F],
+        );
+        check(
+            2u64.pow(56),
+            &[0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x01],
+        );
 
-        check(2u64.pow(63) - 1, &[0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0x7F]);
-        check(2u64.pow(63), &[0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x01]);
+        check(
+            2u64.pow(63) - 1,
+            &[0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0x7F],
+        );
+        check(
+            2u64.pow(63),
+            &[0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x01],
+        );
 
-        check(u64::MAX, &[0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0x01]);
+        check(
+            u64::MAX,
+            &[0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0x01],
+        );
     }
 
     /// This big bowl o' macro soup generates a quickcheck encoding test for each

--- a/src/error.rs
+++ b/src/error.rs
@@ -21,12 +21,14 @@ pub struct DecodeError {
 }
 
 impl DecodeError {
-
     /// Creates a new `DecodeError` with a 'best effort' root cause description.
     ///
     /// Meant to be used only by `Message` implementations.
     #[doc(hidden)]
-    pub fn new<S>(description: S) -> DecodeError where S: Into<Cow<'static, str>> {
+    pub fn new<S>(description: S) -> DecodeError
+    where
+        S: Into<Cow<'static, str>>,
+    {
         DecodeError {
             description: description.into(),
             stack: Vec::new(),
@@ -76,7 +78,6 @@ pub struct EncodeError {
 }
 
 impl EncodeError {
-
     /// Creates a new `EncodeError`.
     pub(crate) fn new(required: usize, remaining: usize) -> EncodeError {
         EncodeError {
@@ -99,7 +100,11 @@ impl EncodeError {
 impl fmt::Display for EncodeError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         f.write_str(error::Error::description(self))?;
-        write!(f, " (required: {}, remaining: {})", self.required, self.remaining)
+        write!(
+            f,
+            " (required: {}, remaining: {})",
+            self.required, self.remaining
+        )
     }
 }
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -99,7 +99,7 @@ impl EncodeError {
 
 impl fmt::Display for EncodeError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        f.write_str(error::Error::description(self))?;
+        f.write_str(self.to_string().as_ref())?;
         write!(
             f,
             " (required: {}, remaining: {})",

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,8 +17,7 @@ pub use message::Message;
 pub use error::{DecodeError, EncodeError};
 
 use bytes::{
-    BufMut,
-    IntoBuf,
+    BufMut, Buf
 };
 
 use encoding::{
@@ -63,8 +62,7 @@ pub fn length_delimiter_len(length: usize) -> usize {
 ///    input is required to decode the full delimiter.
 ///  * If the supplied buffer contains more than 10 bytes, then the buffer contains an invalid
 ///    delimiter, and typically the buffer should be considered corrupt.
-pub fn decode_length_delimiter<B>(buf: B) -> Result<usize, DecodeError> where B: IntoBuf {
-    let mut buf = buf.into_buf();
+pub fn decode_length_delimiter<B>(mut buf: B) -> Result<usize, DecodeError> where B: Buf {
     let length = decode_varint(&mut buf)?;
     if length > usize::max_value() as u64 {
         return Err(DecodeError::new("length delimiter exceeds maximum usize value"));

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,6 @@
 #![doc(html_root_url = "https://docs.rs/prost/0.4.0")]
 
-extern crate bytes;
-
+pub extern crate bytes;
 #[cfg(feature = "prost-derive")]
 #[doc(hidden)]
 #[doc(hidden)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,7 +3,8 @@
 extern crate bytes;
 
 #[cfg(feature = "prost-derive")]
-#[doc(hidden)]	#[doc(hidden)]
+#[doc(hidden)]
+#[doc(hidden)]
 pub use bytes;
 
 #[cfg(test)]
@@ -17,20 +18,12 @@ mod types;
 #[doc(hidden)]
 pub mod encoding;
 
-pub use message::Message;
 pub use error::{DecodeError, EncodeError};
+pub use message::Message;
 
-use bytes::{
-    BufMut, Buf
-};
+use bytes::{Buf, BufMut};
 
-use encoding::{
-    decode_varint,
-    encode_varint,
-    encoded_len_varint,
-};
-
-
+use encoding::{decode_varint, encode_varint, encoded_len_varint};
 
 /// Encodes a length delimiter to the buffer.
 ///
@@ -38,7 +31,10 @@ use encoding::{
 ///
 /// An error will be returned if the buffer does not have sufficient capacity to encode the
 /// delimiter.
-pub fn encode_length_delimiter<B>(length: usize, buf: &mut B) -> Result<(), EncodeError> where B: BufMut {
+pub fn encode_length_delimiter<B>(length: usize, buf: &mut B) -> Result<(), EncodeError>
+where
+    B: BufMut,
+{
     let length = length as u64;
     let required = encoded_len_varint(length);
     let remaining = buf.remaining_mut();
@@ -68,10 +64,15 @@ pub fn length_delimiter_len(length: usize) -> usize {
 ///    input is required to decode the full delimiter.
 ///  * If the supplied buffer contains more than 10 bytes, then the buffer contains an invalid
 ///    delimiter, and typically the buffer should be considered corrupt.
-pub fn decode_length_delimiter<B>(mut buf: B) -> Result<usize, DecodeError> where B: Buf {
+pub fn decode_length_delimiter<B>(mut buf: B) -> Result<usize, DecodeError>
+where
+    B: Buf,
+{
     let length = decode_varint(&mut buf)?;
     if length > usize::max_value() as u64 {
-        return Err(DecodeError::new("length delimiter exceeds maximum usize value"));
+        return Err(DecodeError::new(
+            "length delimiter exceeds maximum usize value",
+        ));
     }
     Ok(length as usize)
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,7 +4,6 @@ pub extern crate bytes;
 
 #[cfg(feature = "prost-derive")]
 #[doc(hidden)]
-#[doc(hidden)]
 pub use bytes;
 
 #[cfg(test)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,6 @@
 #![doc(html_root_url = "https://docs.rs/prost/0.4.0")]
 
-extern crate bytes;
+pub extern crate bytes;
 
 #[cfg(feature = "prost-derive")]
 #[doc(hidden)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,6 +2,10 @@
 
 extern crate bytes;
 
+#[cfg(feature = "prost-derive")]
+#[doc(hidden)]	#[doc(hidden)]
+pub use bytes;
+
 #[cfg(test)]
 #[macro_use]
 extern crate quickcheck;
@@ -25,6 +29,8 @@ use encoding::{
     encode_varint,
     encoded_len_varint,
 };
+
+
 
 /// Encodes a length delimiter to the buffer.
 ///

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,7 @@
 #![doc(html_root_url = "https://docs.rs/prost/0.4.0")]
 
-pub extern crate bytes;
+extern crate bytes;
+
 #[cfg(feature = "prost-derive")]
 #[doc(hidden)]
 #[doc(hidden)]

--- a/src/message.rs
+++ b/src/message.rs
@@ -6,25 +6,28 @@ use bytes::{Buf, BufMut};
 use DecodeError;
 use EncodeError;
 
-use crate::encoding::{
- encode_varint, encoded_len_varint, message, WireType,
-};
+use crate::encoding::{encode_varint, encoded_len_varint, message, WireType};
 /// A Protocol Buffers message.
 pub trait Message: Debug + Send + Sync {
-
     /// Encodes the message to a buffer.
     ///
     /// This method will panic if the buffer has insufficient capacity.
     ///
     /// Meant to be used only by `Message` implementations.
     #[doc(hidden)]
-    fn encode_raw<B>(&self, buf: &mut B) where B: BufMut, Self: Sized;
+    fn encode_raw<B>(&self, buf: &mut B)
+    where
+        B: BufMut,
+        Self: Sized;
 
     /// Decodes a field from a buffer, and merges it into `self`.
     ///
     /// Meant to be used only by `Message` implementations.
     #[doc(hidden)]
-    fn merge_field<B>(&mut self, buf: &mut B) -> Result<(), DecodeError> where B: Buf, Self: Sized;
+    fn merge_field<B>(&mut self, buf: &mut B) -> Result<(), DecodeError>
+    where
+        B: Buf,
+        Self: Sized;
 
     /// Returns the encoded length of the message without a length delimiter.
     fn encoded_len(&self) -> usize;
@@ -32,7 +35,11 @@ pub trait Message: Debug + Send + Sync {
     /// Encodes the message to a buffer.
     ///
     /// An error will be returned if the buffer does not have sufficient capacity.
-    fn encode<B>(&self, buf: &mut B) -> Result<(), EncodeError> where B: BufMut, Self: Sized {
+    fn encode<B>(&self, buf: &mut B) -> Result<(), EncodeError>
+    where
+        B: BufMut,
+        Self: Sized,
+    {
         let required = self.encoded_len();
         let remaining = buf.remaining_mut();
         if required > buf.remaining_mut() {
@@ -46,7 +53,11 @@ pub trait Message: Debug + Send + Sync {
     /// Encodes the message with a length-delimiter to a buffer.
     ///
     /// An error will be returned if the buffer does not have sufficient capacity.
-    fn encode_length_delimited<B>(&self, buf: &mut B) -> Result<(), EncodeError> where B: BufMut, Self: Sized {
+    fn encode_length_delimited<B>(&self, buf: &mut B) -> Result<(), EncodeError>
+    where
+        B: BufMut,
+        Self: Sized,
+    {
         let len = self.encoded_len();
         let required = len + encoded_len_varint(len as u64);
         let remaining = buf.remaining_mut();
@@ -61,13 +72,21 @@ pub trait Message: Debug + Send + Sync {
     /// Decodes an instance of the message from a buffer.
     ///
     /// The entire buffer will be consumed.
-    fn decode<B>(mut buf: B) -> Result<Self, DecodeError> where B: Buf, Self: Default {
+    fn decode<B>(mut buf: B) -> Result<Self, DecodeError>
+    where
+        B: Buf,
+        Self: Default,
+    {
         let mut message = Self::default();
         Self::merge(&mut message, &mut buf).map(|_| message)
     }
 
     /// Decodes a length-delimited instance of the message from the buffer.
-    fn decode_length_delimited<B>(buf: B) -> Result<Self, DecodeError> where B: Buf, Self: Default {
+    fn decode_length_delimited<B>(buf: B) -> Result<Self, DecodeError>
+    where
+        B: Buf,
+        Self: Default,
+    {
         let mut message = Self::default();
         message.merge_length_delimited(buf)?;
         Ok(message)
@@ -76,7 +95,11 @@ pub trait Message: Debug + Send + Sync {
     /// Decodes an instance of the message from a buffer, and merges it into `self`.
     ///
     /// The entire buffer will be consumed.
-    fn merge<B>(&mut self, buf: B) -> Result<(), DecodeError> where B: Buf, Self: Sized {
+    fn merge<B>(&mut self, buf: B) -> Result<(), DecodeError>
+    where
+        B: Buf,
+        Self: Sized,
+    {
         let mut buf = buf;
         while buf.has_remaining() {
             self.merge_field(&mut buf)?;
@@ -86,7 +109,11 @@ pub trait Message: Debug + Send + Sync {
 
     /// Decodes a length-delimited instance of the message from buffer, and
     /// merges it into `self`.
-    fn merge_length_delimited<B>(&mut self, mut buf: B) -> Result<(), DecodeError> where B: Buf, Self: Sized {
+    fn merge_length_delimited<B>(&mut self, mut buf: B) -> Result<(), DecodeError>
+    where
+        B: Buf,
+        Self: Sized,
+    {
         message::merge(WireType::LengthDelimited, self, &mut buf)
     }
 
@@ -94,11 +121,20 @@ pub trait Message: Debug + Send + Sync {
     fn clear(&mut self);
 }
 
-impl <M> Message for Box<M> where M: Message {
-    fn encode_raw<B>(&self, buf: &mut B) where B: BufMut {
+impl<M> Message for Box<M>
+where
+    M: Message,
+{
+    fn encode_raw<B>(&self, buf: &mut B)
+    where
+        B: BufMut,
+    {
         (**self).encode_raw(buf)
     }
-    fn merge_field<B>(&mut self, buf: &mut B) -> Result<(), DecodeError> where B: Buf {
+    fn merge_field<B>(&mut self, buf: &mut B) -> Result<(), DecodeError>
+    where
+        B: Buf,
+    {
         (**self).merge_field(buf)
     }
     fn encoded_len(&self) -> usize {

--- a/src/types.rs
+++ b/src/types.rs
@@ -7,18 +7,24 @@
 
 use bytes::{Buf, BufMut};
 
+use encoding::*;
 use DecodeError;
 use Message;
-use encoding::*;
 
 /// `google.protobuf.BoolValue`
 impl Message for bool {
-    fn encode_raw<B>(&self, buf: &mut B) where B: BufMut {
+    fn encode_raw<B>(&self, buf: &mut B)
+    where
+        B: BufMut,
+    {
         if *self {
             bool::encode(1, self, buf)
         }
     }
-    fn merge_field<B>(&mut self, buf: &mut B) -> Result<(), DecodeError> where B: Buf {
+    fn merge_field<B>(&mut self, buf: &mut B) -> Result<(), DecodeError>
+    where
+        B: Buf,
+    {
         let (tag, wire_type) = decode_key(buf)?;
         if tag == 1 {
             bool::merge(wire_type, self, buf)
@@ -27,7 +33,11 @@ impl Message for bool {
         }
     }
     fn encoded_len(&self) -> usize {
-        if *self { 2 } else { 0 }
+        if *self {
+            2
+        } else {
+            0
+        }
     }
     fn clear(&mut self) {
         *self = false;
@@ -36,12 +46,18 @@ impl Message for bool {
 
 /// `google.protobuf.UInt32Value`
 impl Message for u32 {
-    fn encode_raw<B>(&self, buf: &mut B) where B: BufMut {
+    fn encode_raw<B>(&self, buf: &mut B)
+    where
+        B: BufMut,
+    {
         if *self != 0 {
             uint32::encode(1, self, buf)
         }
     }
-    fn merge_field<B>(&mut self, buf: &mut B) -> Result<(), DecodeError> where B: Buf {
+    fn merge_field<B>(&mut self, buf: &mut B) -> Result<(), DecodeError>
+    where
+        B: Buf,
+    {
         let (tag, wire_type) = decode_key(buf)?;
         if tag == 1 {
             uint32::merge(wire_type, self, buf)
@@ -50,7 +66,11 @@ impl Message for u32 {
         }
     }
     fn encoded_len(&self) -> usize {
-        if *self != 0 { uint32::encoded_len(1, self) } else { 0 }
+        if *self != 0 {
+            uint32::encoded_len(1, self)
+        } else {
+            0
+        }
     }
     fn clear(&mut self) {
         *self = 0;
@@ -59,12 +79,18 @@ impl Message for u32 {
 
 /// `google.protobuf.UInt64Value`
 impl Message for u64 {
-    fn encode_raw<B>(&self, buf: &mut B) where B: BufMut {
+    fn encode_raw<B>(&self, buf: &mut B)
+    where
+        B: BufMut,
+    {
         if *self != 0 {
             uint64::encode(1, self, buf)
         }
     }
-    fn merge_field<B>(&mut self, buf: &mut B) -> Result<(), DecodeError> where B: Buf {
+    fn merge_field<B>(&mut self, buf: &mut B) -> Result<(), DecodeError>
+    where
+        B: Buf,
+    {
         let (tag, wire_type) = decode_key(buf)?;
         if tag == 1 {
             uint64::merge(wire_type, self, buf)
@@ -73,7 +99,11 @@ impl Message for u64 {
         }
     }
     fn encoded_len(&self) -> usize {
-        if *self != 0 { uint64::encoded_len(1, self) } else { 0 }
+        if *self != 0 {
+            uint64::encoded_len(1, self)
+        } else {
+            0
+        }
     }
     fn clear(&mut self) {
         *self = 0;
@@ -82,12 +112,18 @@ impl Message for u64 {
 
 /// `google.protobuf.Int32Value`
 impl Message for i32 {
-    fn encode_raw<B>(&self, buf: &mut B) where B: BufMut {
+    fn encode_raw<B>(&self, buf: &mut B)
+    where
+        B: BufMut,
+    {
         if *self != 0 {
             int32::encode(1, self, buf)
         }
     }
-    fn merge_field<B>(&mut self, buf: &mut B) -> Result<(), DecodeError> where B: Buf {
+    fn merge_field<B>(&mut self, buf: &mut B) -> Result<(), DecodeError>
+    where
+        B: Buf,
+    {
         let (tag, wire_type) = decode_key(buf)?;
         if tag == 1 {
             int32::merge(wire_type, self, buf)
@@ -96,7 +132,11 @@ impl Message for i32 {
         }
     }
     fn encoded_len(&self) -> usize {
-        if *self != 0 { int32::encoded_len(1, self) } else { 0 }
+        if *self != 0 {
+            int32::encoded_len(1, self)
+        } else {
+            0
+        }
     }
     fn clear(&mut self) {
         *self = 0;
@@ -105,12 +145,18 @@ impl Message for i32 {
 
 /// `google.protobuf.Int64Value`
 impl Message for i64 {
-    fn encode_raw<B>(&self, buf: &mut B) where B: BufMut {
+    fn encode_raw<B>(&self, buf: &mut B)
+    where
+        B: BufMut,
+    {
         if *self != 0 {
             int64::encode(1, self, buf)
         }
     }
-    fn merge_field<B>(&mut self, buf: &mut B) -> Result<(), DecodeError> where B: Buf {
+    fn merge_field<B>(&mut self, buf: &mut B) -> Result<(), DecodeError>
+    where
+        B: Buf,
+    {
         let (tag, wire_type) = decode_key(buf)?;
         if tag == 1 {
             int64::merge(wire_type, self, buf)
@@ -119,7 +165,11 @@ impl Message for i64 {
         }
     }
     fn encoded_len(&self) -> usize {
-        if *self != 0 { int64::encoded_len(1, self) } else { 0 }
+        if *self != 0 {
+            int64::encoded_len(1, self)
+        } else {
+            0
+        }
     }
     fn clear(&mut self) {
         *self = 0;
@@ -128,12 +178,18 @@ impl Message for i64 {
 
 /// `google.protobuf.FloatValue`
 impl Message for f32 {
-    fn encode_raw<B>(&self, buf: &mut B) where B: BufMut {
+    fn encode_raw<B>(&self, buf: &mut B)
+    where
+        B: BufMut,
+    {
         if *self != 0.0 {
             float::encode(1, self, buf)
         }
     }
-    fn merge_field<B>(&mut self, buf: &mut B) -> Result<(), DecodeError> where B: Buf {
+    fn merge_field<B>(&mut self, buf: &mut B) -> Result<(), DecodeError>
+    where
+        B: Buf,
+    {
         let (tag, wire_type) = decode_key(buf)?;
         if tag == 1 {
             float::merge(wire_type, self, buf)
@@ -142,7 +198,11 @@ impl Message for f32 {
         }
     }
     fn encoded_len(&self) -> usize {
-        if *self != 0.0 { float::encoded_len(1, self) } else { 0 }
+        if *self != 0.0 {
+            float::encoded_len(1, self)
+        } else {
+            0
+        }
     }
     fn clear(&mut self) {
         *self = 0.0;
@@ -151,12 +211,18 @@ impl Message for f32 {
 
 /// `google.protobuf.DoubleValue`
 impl Message for f64 {
-    fn encode_raw<B>(&self, buf: &mut B) where B: BufMut {
+    fn encode_raw<B>(&self, buf: &mut B)
+    where
+        B: BufMut,
+    {
         if *self != 0.0 {
             double::encode(1, self, buf)
         }
     }
-    fn merge_field<B>(&mut self, buf: &mut B) -> Result<(), DecodeError> where B: Buf {
+    fn merge_field<B>(&mut self, buf: &mut B) -> Result<(), DecodeError>
+    where
+        B: Buf,
+    {
         let (tag, wire_type) = decode_key(buf)?;
         if tag == 1 {
             double::merge(wire_type, self, buf)
@@ -165,7 +231,11 @@ impl Message for f64 {
         }
     }
     fn encoded_len(&self) -> usize {
-        if *self != 0.0 { double::encoded_len(1, self) } else { 0 }
+        if *self != 0.0 {
+            double::encoded_len(1, self)
+        } else {
+            0
+        }
     }
     fn clear(&mut self) {
         *self = 0.0;
@@ -174,12 +244,18 @@ impl Message for f64 {
 
 /// `google.protobuf.StringValue`
 impl Message for String {
-    fn encode_raw<B>(&self, buf: &mut B) where B: BufMut {
+    fn encode_raw<B>(&self, buf: &mut B)
+    where
+        B: BufMut,
+    {
         if !self.is_empty() {
             string::encode(1, self, buf)
         }
     }
-    fn merge_field<B>(&mut self, buf: &mut B) -> Result<(), DecodeError> where B: Buf {
+    fn merge_field<B>(&mut self, buf: &mut B) -> Result<(), DecodeError>
+    where
+        B: Buf,
+    {
         let (tag, wire_type) = decode_key(buf)?;
         if tag == 1 {
             string::merge(wire_type, self, buf)
@@ -188,7 +264,11 @@ impl Message for String {
         }
     }
     fn encoded_len(&self) -> usize {
-        if !self.is_empty() { string::encoded_len(1, self) } else { 0 }
+        if !self.is_empty() {
+            string::encoded_len(1, self)
+        } else {
+            0
+        }
     }
     fn clear(&mut self) {
         self.clear();
@@ -197,12 +277,18 @@ impl Message for String {
 
 /// `google.protobuf.BytesValue`
 impl Message for Vec<u8> {
-    fn encode_raw<B>(&self, buf: &mut B) where B: BufMut {
+    fn encode_raw<B>(&self, buf: &mut B)
+    where
+        B: BufMut,
+    {
         if !self.is_empty() {
             bytes::encode(1, self, buf)
         }
     }
-    fn merge_field<B>(&mut self, buf: &mut B) -> Result<(), DecodeError> where B: Buf {
+    fn merge_field<B>(&mut self, buf: &mut B) -> Result<(), DecodeError>
+    where
+        B: Buf,
+    {
         let (tag, wire_type) = decode_key(buf)?;
         if tag == 1 {
             bytes::merge(wire_type, self, buf)
@@ -211,7 +297,11 @@ impl Message for Vec<u8> {
         }
     }
     fn encoded_len(&self) -> usize {
-        if !self.is_empty() { bytes::encoded_len(1, self) } else { 0 }
+        if !self.is_empty() {
+            bytes::encoded_len(1, self)
+        } else {
+            0
+        }
     }
     fn clear(&mut self) {
         self.clear();
@@ -220,11 +310,20 @@ impl Message for Vec<u8> {
 
 /// `google.protobuf.Empty`
 impl Message for () {
-    fn encode_raw<B>(&self, _buf: &mut B) where B: BufMut { }
-    fn merge_field<B>(&mut self, buf: &mut B) -> Result<(), DecodeError> where B: Buf {
+    fn encode_raw<B>(&self, _buf: &mut B)
+    where
+        B: BufMut,
+    {
+    }
+    fn merge_field<B>(&mut self, buf: &mut B) -> Result<(), DecodeError>
+    where
+        B: Buf,
+    {
         let (_, wire_type) = decode_key(buf)?;
         skip_field(wire_type, buf)
     }
-    fn encoded_len(&self) -> usize { 0 }
-    fn clear(&mut self) { }
+    fn encoded_len(&self) -> usize {
+        0
+    }
+    fn clear(&mut self) {}
 }

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -14,7 +14,7 @@ build = "src/build.rs"
 doctest = false
 
 [dependencies]
-bytes = "0.4.7"
+bytes = "0.5"
 prost-amino = { path = ".." }
 prost-amino-derive = { path = "../prost-amino-derive" }
 prost-types = { path = "../prost-types" }

--- a/tests/src/amino.rs
+++ b/tests/src/amino.rs
@@ -1,31 +1,27 @@
-
 extern crate prost_amino as prost;
 use prost::Message;
 
-
 #[test]
 fn amino() {
-
     #[derive(Clone, PartialEq, Message)]
     pub struct PartsSetHeader {
-        #[prost(sint64, tag="1")]
+        #[prost(sint64, tag = "1")]
         total: i64,
-        #[prost(bytes, tag="2")]
+        #[prost(bytes, tag = "2")]
         hash: Vec<u8>,
     }
 
-
     #[derive(Clone, PartialEq, Message)]
     pub struct BlockID {
-        #[prost(bytes, tag="1")]
+        #[prost(bytes, tag = "1")]
         hash: Vec<u8>,
-        #[prost(message, tag="2")]
+        #[prost(message, tag = "2")]
         parts_header: Option<PartsSetHeader>,
     }
 
     #[derive(Clone, PartialEq, Message)]
     struct Heartbeat {
-        #[prost(bytes, tag="1")]
+        #[prost(bytes, tag = "1")]
         pub validator_address: Vec<u8>,
         #[prost(sint64)]
         validator_index: i64,
@@ -40,14 +36,14 @@ fn amino() {
     }
 
     #[derive(Clone, PartialEq, Message)]
-    #[amino_name="tendermint/socketpv/SignHeartbeatMsg"]
+    #[amino_name = "tendermint/socketpv/SignHeartbeatMsg"]
     struct SignHeartbeatMsg {
-        #[prost(message, tag="1")]
+        #[prost(message, tag = "1")]
         heartbeat: Option<Heartbeat>,
     }
     let addr = vec![
-        0xa3, 0xb2, 0xcc, 0xdd, 0x71, 0x86, 0xf1, 0x68, 0x5f, 0x21, 0xf2, 0x48, 0x2a, 0xf4,
-        0xfb, 0x34, 0x46, 0xa8, 0x4b, 0x35,
+        0xa3, 0xb2, 0xcc, 0xdd, 0x71, 0x86, 0xf1, 0x68, 0x5f, 0x21, 0xf2, 0x48, 0x2a, 0xf4, 0xfb,
+        0x34, 0x46, 0xa8, 0x4b, 0x35,
     ];
 
     let hb = Heartbeat {
@@ -65,13 +61,13 @@ fn amino() {
 
     let mut buf = vec![];
     let _enc = hb_msg.encode(&mut buf).unwrap();
-    let want = vec![0x24, 0xbf, 0x58, 0xca, 0xef, 0xa, 0x1e, 0xa, 0x14, 0xa3,
-                    0xb2, 0xcc, 0xdd, 0x71, 0x86, 0xf1, 0x68, 0x5f, 0x21, 0xf2, 0x48,
-                    0x2a, 0xf4, 0xfb, 0x34, 0x46, 0xa8, 0x4b, 0x35, 0x10, 0x2, 0x18, 0x1e,
-                    0x20, 0x14, 0x28, 0x3c];
+    let want = vec![
+        0x24, 0xbf, 0x58, 0xca, 0xef, 0xa, 0x1e, 0xa, 0x14, 0xa3, 0xb2, 0xcc, 0xdd, 0x71, 0x86,
+        0xf1, 0x68, 0x5f, 0x21, 0xf2, 0x48, 0x2a, 0xf4, 0xfb, 0x34, 0x46, 0xa8, 0x4b, 0x35, 0x10,
+        0x2, 0x18, 0x1e, 0x20, 0x14, 0x28, 0x3c,
+    ];
     assert_eq!(want, buf);
 
     let hb2 = SignHeartbeatMsg::decode(want);
     assert_eq!(hb_msg, hb2.unwrap());
 }
-

--- a/tests/src/bootstrap.rs
+++ b/tests/src/bootstrap.rs
@@ -4,14 +4,16 @@ use std::io::Read;
 use std::io::Write;
 use std::path::Path;
 
-use tempdir;
 use prost_build;
+use tempdir;
 
 /// Test which bootstraps protobuf.rs and compiler.rs from the .proto definitions in the Protobuf
 /// repo. Ensures that the checked-in compiled versions are up-to-date.
 #[test]
 fn bootstrap() {
-    let protobuf = Path::new(prost_build::protoc_include()).join("google").join("protobuf");
+    let protobuf = Path::new(prost_build::protoc_include())
+        .join("google")
+        .join("protobuf");
 
     let tempdir = tempdir::TempDir::new("prost-types-bootstrap").unwrap();
     env::set_var("OUT_DIR", tempdir.path());
@@ -19,47 +21,68 @@ fn bootstrap() {
     let mut config = prost_build::Config::new();
     config.compile_well_known_types();
     config.btree_map(&["."]);
-    config.compile_protos(&[
-                            // Protobuf Plugins.
-                            protobuf.join("descriptor.proto"),
-                            protobuf.join("compiler").join("plugin.proto"),
-                            // Well-known Types (except wrapper.proto, whose types are substituted
-                            // for the corresponding standard library types).
-                            protobuf.join("any.proto"),
-                            protobuf.join("api.proto"),
-                            protobuf.join("duration.proto"),
-                            protobuf.join("field_mask.proto"),
-                            protobuf.join("source_context.proto"),
-                            protobuf.join("struct.proto"),
-                            protobuf.join("timestamp.proto"),
-                            protobuf.join("type.proto"),
-                          ], &[]).unwrap();
+    config
+        .compile_protos(
+            &[
+                // Protobuf Plugins.
+                protobuf.join("descriptor.proto"),
+                protobuf.join("compiler").join("plugin.proto"),
+                // Well-known Types (except wrapper.proto, whose types are substituted
+                // for the corresponding standard library types).
+                protobuf.join("any.proto"),
+                protobuf.join("api.proto"),
+                protobuf.join("duration.proto"),
+                protobuf.join("field_mask.proto"),
+                protobuf.join("source_context.proto"),
+                protobuf.join("struct.proto"),
+                protobuf.join("timestamp.proto"),
+                protobuf.join("type.proto"),
+            ],
+            &[],
+        )
+        .unwrap();
 
     let mut bootstrapped_protobuf = String::new();
-    fs::File::open(tempdir.path().join("google.protobuf.rs")).unwrap()
-             .read_to_string(&mut bootstrapped_protobuf).unwrap();
+    fs::File::open(tempdir.path().join("google.protobuf.rs"))
+        .unwrap()
+        .read_to_string(&mut bootstrapped_protobuf)
+        .unwrap();
 
     let mut bootstrapped_compiler = String::new();
-    fs::File::open(tempdir.path().join("google.protobuf.compiler.rs")).unwrap()
-             .read_to_string(&mut bootstrapped_compiler).unwrap();
+    fs::File::open(tempdir.path().join("google.protobuf.compiler.rs"))
+        .unwrap()
+        .read_to_string(&mut bootstrapped_compiler)
+        .unwrap();
 
-    let src = Path::new(env!("CARGO_MANIFEST_DIR")).parent().expect("no parent").join("prost-types").join("src");
+    let src = Path::new(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .expect("no parent")
+        .join("prost-types")
+        .join("src");
 
     let mut protobuf = String::new();
-    fs::File::open(src.join("protobuf.rs")).unwrap()
-             .read_to_string(&mut protobuf).unwrap();
+    fs::File::open(src.join("protobuf.rs"))
+        .unwrap()
+        .read_to_string(&mut protobuf)
+        .unwrap();
 
     let mut compiler = String::new();
-    fs::File::open(src.join("compiler.rs")).unwrap()
-             .read_to_string(&mut compiler).unwrap();
+    fs::File::open(src.join("compiler.rs"))
+        .unwrap()
+        .read_to_string(&mut compiler)
+        .unwrap();
 
     if protobuf != bootstrapped_protobuf {
-        fs::File::create(src.join("protobuf.rs")).unwrap()
-                 .write_all(bootstrapped_protobuf.as_bytes()).unwrap();
+        fs::File::create(src.join("protobuf.rs"))
+            .unwrap()
+            .write_all(bootstrapped_protobuf.as_bytes())
+            .unwrap();
     }
     if compiler != bootstrapped_compiler {
-        fs::File::create(src.join("compiler.rs")).unwrap()
-                 .write_all(bootstrapped_compiler.as_bytes()).unwrap();
+        fs::File::create(src.join("compiler.rs"))
+            .unwrap()
+            .write_all(bootstrapped_compiler.as_bytes())
+            .unwrap();
     }
 
     assert_eq!(protobuf, bootstrapped_protobuf);

--- a/tests/src/build.rs
+++ b/tests/src/build.rs
@@ -15,45 +15,69 @@ fn main() {
     prost_build.btree_map(&["."]);
     // Tests for custom attributes
     prost_build.type_attribute("Foo.Bar_Baz.Foo_barBaz", "#[derive(Eq, PartialOrd, Ord)]");
-    prost_build.type_attribute("Foo.Bar_Baz.Foo_barBaz.fuzz_buster",
-                               "#[derive(Eq, PartialOrd, Ord)]");
+    prost_build.type_attribute(
+        "Foo.Bar_Baz.Foo_barBaz.fuzz_buster",
+        "#[derive(Eq, PartialOrd, Ord)]",
+    );
     prost_build.type_attribute("Foo.Custom.Attrs.Msg", "#[allow(missing_docs)]");
     prost_build.type_attribute("Foo.Custom.Attrs.Msg.field", "/// Oneof docs");
     prost_build.type_attribute("Foo.Custom.Attrs.AnEnum", "#[allow(missing_docs)]");
     prost_build.type_attribute("Foo.Custom.Attrs.AnotherEnum", "/// Oneof docs");
-    prost_build.type_attribute("Foo.Custom.OneOfAttrs.Msg.field", "#[derive(Eq, PartialOrd, Ord)]");
+    prost_build.type_attribute(
+        "Foo.Custom.OneOfAttrs.Msg.field",
+        "#[derive(Eq, PartialOrd, Ord)]",
+    );
     prost_build.field_attribute("Foo.Custom.Attrs.AnotherEnum.C", "/// The C docs");
     prost_build.field_attribute("Foo.Custom.Attrs.AnotherEnum.D", "/// The D docs");
     prost_build.field_attribute("Foo.Custom.Attrs.Msg.field.a", "/// Oneof A docs");
     prost_build.field_attribute("Foo.Custom.Attrs.Msg.field.b", "/// Oneof B docs");
 
-    prost_build.compile_protos(&[proto_includes.join("test_messages_proto2.proto")],
-                               &[protobuf::include()]).unwrap();
+    prost_build
+        .compile_protos(
+            &[proto_includes.join("test_messages_proto2.proto")],
+            &[protobuf::include()],
+        )
+        .unwrap();
 
-    prost_build.compile_protos(&[proto_includes.join("test_messages_proto3.proto")],
-                               &[protobuf::include()]).unwrap();
+    prost_build
+        .compile_protos(
+            &[proto_includes.join("test_messages_proto3.proto")],
+            &[protobuf::include()],
+        )
+        .unwrap();
 
-    prost_build.compile_protos(&[proto_includes.join("unittest.proto")],
-                               &[protobuf::include()]).unwrap();
+    prost_build
+        .compile_protos(
+            &[proto_includes.join("unittest.proto")],
+            &[protobuf::include()],
+        )
+        .unwrap();
 
-    prost_build.compile_protos(&["src/packages/widget_factory.proto"],
-                               &["src/packages"]).unwrap();
+    prost_build
+        .compile_protos(&["src/packages/widget_factory.proto"], &["src/packages"])
+        .unwrap();
 
-    prost_build.compile_protos(&["src/ident_conversion.proto"],
-                               &["src"]).unwrap();
+    prost_build
+        .compile_protos(&["src/ident_conversion.proto"], &["src"])
+        .unwrap();
 
-    prost_build.compile_protos(&["src/nesting.proto"],
-                               &["src"]).unwrap();
+    prost_build
+        .compile_protos(&["src/nesting.proto"], &["src"])
+        .unwrap();
 
-    prost_build.compile_protos(&["src/recursive_oneof.proto"],
-                               &["src"]).unwrap();
+    prost_build
+        .compile_protos(&["src/recursive_oneof.proto"], &["src"])
+        .unwrap();
 
-    prost_build.compile_protos(&["src/custom_attributes.proto"],
-                               &["src"]).unwrap();
+    prost_build
+        .compile_protos(&["src/custom_attributes.proto"], &["src"])
+        .unwrap();
 
-    prost_build.compile_protos(&["src/oneof_attributes.proto"],
-                               &["src"]).unwrap();
+    prost_build
+        .compile_protos(&["src/oneof_attributes.proto"], &["src"])
+        .unwrap();
 
-    prost_build.compile_protos(&["src/no_unused_results.proto"],
-                               &["src"]).unwrap();
+    prost_build
+        .compile_protos(&["src/no_unused_results.proto"], &["src"])
+        .unwrap();
 }

--- a/tests/src/debug.rs
+++ b/tests/src/debug.rs
@@ -4,14 +4,15 @@
 //! actual use.
 
 // Borrow some types from other places.
-use ::message_encoding::{Basic, BasicEnumeration};
+use message_encoding::{Basic, BasicEnumeration};
 
 /// Some real-life message
 #[test]
 fn basic() {
     let mut basic = Basic::default();
-    assert_eq!(format!("{:?}", basic),
-               "Basic { \
+    assert_eq!(
+        format!("{:?}", basic),
+        "Basic { \
                     int32: 0, \
                     bools: [], \
                     string: \"\", \
@@ -22,11 +23,15 @@ fn basic() {
                     enumeration_btree_map: {}, \
                     string_btree_map: {}, \
                     oneof: None \
-                }");
-    basic.enumeration_map.insert(0, BasicEnumeration::TWO as i32);
+                }"
+    );
+    basic
+        .enumeration_map
+        .insert(0, BasicEnumeration::TWO as i32);
     basic.enumeration = 42;
-    assert_eq!(format!("{:?}", basic),
-               "Basic { \
+    assert_eq!(
+        format!("{:?}", basic),
+        "Basic { \
                     int32: 0, \
                     bools: [], \
                     string: \"\", \
@@ -37,7 +42,8 @@ fn basic() {
                     enumeration_btree_map: {}, \
                     string_btree_map: {}, \
                     oneof: None \
-                }");
+                }"
+    );
 }
 
 /*
@@ -58,17 +64,17 @@ fn tuple_struct() {
 
 #[derive(Clone, PartialEq, Oneof)]
 pub enum OneofWithEnum {
-    #[prost(int32, tag="8")]
+    #[prost(int32, tag = "8")]
     Int(i32),
-    #[prost(string, tag="9")]
+    #[prost(string, tag = "9")]
     String(String),
-    #[prost(enumeration="BasicEnumeration", tag="10")]
+    #[prost(enumeration = "BasicEnumeration", tag = "10")]
     Enumeration(i32),
 }
 
 #[derive(Clone, PartialEq, Message)]
 struct MessageWithOneof {
-    #[prost(oneof="OneofWithEnum", tags="8, 9, 10")]
+    #[prost(oneof = "OneofWithEnum", tags = "8, 9, 10")]
     of: Option<OneofWithEnum>,
 }
 
@@ -76,7 +82,10 @@ struct MessageWithOneof {
 #[test]
 fn oneof_with_enum() {
     let msg = MessageWithOneof {
-        of: Some(OneofWithEnum::Enumeration(BasicEnumeration::TWO as i32))
+        of: Some(OneofWithEnum::Enumeration(BasicEnumeration::TWO as i32)),
     };
-    assert_eq!(format!("{:?}", msg), "MessageWithOneof { of: Some(Enumeration(TWO)) }");
+    assert_eq!(
+        format!("{:?}", msg),
+        "MessageWithOneof { of: Some(Enumeration(TWO)) }"
+    );
 }

--- a/tests/src/lib.rs
+++ b/tests/src/lib.rs
@@ -1,4 +1,4 @@
-pub extern crate bytes;
+extern crate bytes;
 extern crate prost_amino;
 extern crate prost_types;
 

--- a/tests/src/lib.rs
+++ b/tests/src/lib.rs
@@ -1,4 +1,4 @@
-extern crate bytes;
+pub extern crate bytes;
 extern crate prost_amino;
 extern crate prost_types;
 

--- a/tests/src/lib.rs
+++ b/tests/src/lib.rs
@@ -66,7 +66,7 @@ pub mod oneof_attributes {
 
 use std::error::Error;
 
-use bytes::{Buf, IntoBuf};
+use bytes::Buf;
 
 use prost::Message;
 
@@ -157,7 +157,6 @@ pub fn check_message<M>(msg: &M) where M: Message + Default + PartialEq {
     msg.encode(&mut buf).unwrap();
     assert_eq!(expected_len, buf.len());
 
-    let mut buf = buf.into_buf();
     let roundtrip = M::decode(&mut buf).unwrap();
 
     if buf.has_remaining() {

--- a/tests/src/lib.rs
+++ b/tests/src/lib.rs
@@ -2,26 +2,39 @@ extern crate bytes;
 extern crate prost_amino;
 extern crate prost_types;
 
-#[macro_use] extern crate prost_amino_derive;
+#[macro_use]
+extern crate prost_amino_derive;
 
-#[cfg(test)] extern crate tempdir;
-#[cfg(test)] extern crate prost_build;
+#[cfg(test)]
+extern crate prost_build;
+#[cfg(test)]
+extern crate tempdir;
 
+pub mod amino;
 pub mod packages;
 pub mod unittest;
-pub mod amino;
 
-#[cfg(test)] mod bootstrap;
-#[cfg(test)] mod debug;
-#[cfg(test)] mod message_encoding;
-#[cfg(test)] mod no_unused_results;
+#[cfg(test)]
+mod bootstrap;
+#[cfg(test)]
+mod debug;
+#[cfg(test)]
+mod message_encoding;
+#[cfg(test)]
+mod no_unused_results;
 
 pub mod protobuf_test_messages {
     pub mod proto2 {
-        include!(concat!(env!("OUT_DIR"), "/protobuf_test_messages.proto2.rs"));
+        include!(concat!(
+            env!("OUT_DIR"),
+            "/protobuf_test_messages.proto2.rs"
+        ));
     }
     pub mod proto3 {
-        include!(concat!(env!("OUT_DIR"), "/protobuf_test_messages.proto3.rs"));
+        include!(concat!(
+            env!("OUT_DIR"),
+            "/protobuf_test_messages.proto3.rs"
+        ));
     }
 }
 
@@ -85,7 +98,9 @@ impl RoundtripResult {
     pub fn unwrap(self) -> Vec<u8> {
         match self {
             RoundtripResult::Ok(buf) => buf,
-            RoundtripResult::DecodeError(error) => panic!("failed to decode the roundtrip data: {}", error),
+            RoundtripResult::DecodeError(error) => {
+                panic!("failed to decode the roundtrip data: {}", error)
+            }
             RoundtripResult::Error(error) => panic!("failed roundtrip: {}", error),
         }
     }
@@ -102,7 +117,10 @@ impl RoundtripResult {
 
 /// Tests round-tripping a message type. The message should be compiled with `BTreeMap` fields,
 /// otherwise the comparison may fail due to inconsistent `HashMap` entry encoding ordering.
-pub fn roundtrip<M>(data: &[u8]) -> RoundtripResult where M: Message + Default {
+pub fn roundtrip<M>(data: &[u8]) -> RoundtripResult
+where
+    M: Message + Default,
+{
     // Try to decode a message from the data. If decoding fails, continue.
     let all_types = match M::decode(data) {
         Ok(all_types) => all_types,
@@ -113,7 +131,7 @@ pub fn roundtrip<M>(data: &[u8]) -> RoundtripResult where M: Message + Default {
 
     // TODO: Reenable this once sign-extension in negative int32s is figured out.
     //assert!(encoded_len <= len, "encoded_len: {}, len: {}, all_types: {:?}",
-                                //encoded_len, len, all_types);
+    //encoded_len, len, all_types);
 
     let mut buf1 = Vec::new();
     if let Err(error) = all_types.encode(&mut buf1) {
@@ -121,8 +139,13 @@ pub fn roundtrip<M>(data: &[u8]) -> RoundtripResult where M: Message + Default {
     }
     if encoded_len != buf1.len() {
         return RoundtripResult::Error(
-            format!("expected encoded len ({}) did not match actual encoded len ({})",
-                    encoded_len, buf1.len()).into());
+            format!(
+                "expected encoded len ({}) did not match actual encoded len ({})",
+                encoded_len,
+                buf1.len()
+            )
+            .into(),
+        );
     }
 
     let roundtrip = match M::decode(&buf1) {
@@ -143,14 +166,17 @@ pub fn roundtrip<M>(data: &[u8]) -> RoundtripResult where M: Message + Default {
     */
 
     if buf1 != buf2 {
-        return RoundtripResult::Error("roundtripped encoded buffers do not match".into())
+        return RoundtripResult::Error("roundtripped encoded buffers do not match".into());
     }
 
     RoundtripResult::Ok(buf1)
 }
 
 /// Generic rountrip serialization check for messages.
-pub fn check_message<M>(msg: &M) where M: Message + Default + PartialEq {
+pub fn check_message<M>(msg: &M)
+where
+    M: Message + Default + PartialEq,
+{
     let expected_len = msg.encoded_len();
 
     let mut buf = Vec::with_capacity(18);
@@ -168,8 +194,10 @@ pub fn check_message<M>(msg: &M) where M: Message + Default + PartialEq {
 
 /// Serialize from A should equal Serialize from B
 pub fn check_serialize_equivalent<M, N>(msg_a: &M, msg_b: &N)
-where M: Message + Default + PartialEq,
-      N: Message + Default + PartialEq {
+where
+    M: Message + Default + PartialEq,
+    N: Message + Default + PartialEq,
+{
     let mut buf_a = Vec::new();
     msg_a.encode(&mut buf_a).unwrap();
     let mut buf_b = Vec::new();
@@ -182,8 +210,8 @@ mod tests {
 
     use std::collections::{BTreeMap, BTreeSet};
 
-    use protobuf_test_messages::proto3::TestAllTypesProto3;
     use super::*;
+    use protobuf_test_messages::proto3::TestAllTypesProto3;
 
     #[test]
     fn test_all_types_proto3() {
@@ -193,23 +221,20 @@ mod tests {
             &[0x92, 0x01, 0x00, 0x92, 0xF4, 0x01, 0x02, 0x00, 0x00],
             &[0x5d, 0xff, 0xff, 0xff, 0xff, 0x28, 0xff, 0xff, 0x21],
             &[0x98, 0x04, 0x02, 0x08, 0x0B, 0x98, 0x04, 0x02, 0x08, 0x02],
-
             // optional_int32: -1
             &[0x08, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0x08],
-
             // repeated_bool: [true, true]
             &[0xDA, 0x02, 0x02, 0x2A, 0x03],
-
             // oneof_double: nan
             &[0xb1, 0x07, 0xf6, 0x3d, 0xf5, 0xff, 0x27, 0x3d, 0xf5, 0xff],
-
             // optional_float: -0.0
             &[0xdd, 0x00, 0x00, 0x00, 0x00, 0x80],
-
             // optional_value: nan
-            &[0xE2, 0x13, 0x1B, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11,
-              0x11, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11,
-              0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0x08, 0xFF, 0x0E],
+            &[
+                0xE2, 0x13, 0x1B, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11,
+                0x11, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF,
+                0xFF, 0xFF, 0x08, 0xFF, 0x0E,
+            ],
         ];
 
         for msg in msgs {
@@ -221,12 +246,10 @@ mod tests {
     fn test_ident_conversions() {
         let msg = foo::bar_baz::FooBarBaz {
             foo_bar_baz: 42,
-            fuzz_busters: vec![
-                foo::bar_baz::foo_bar_baz::FuzzBuster {
-                    t: BTreeMap::<i32, foo::bar_baz::FooBarBaz>::new(),
-                    nested_self: None,
-                },
-            ],
+            fuzz_busters: vec![foo::bar_baz::foo_bar_baz::FuzzBuster {
+                t: BTreeMap::<i32, foo::bar_baz::FooBarBaz>::new(),
+                nested_self: None,
+            }],
             p_i_e: 0,
         };
 
@@ -274,9 +297,9 @@ mod tests {
         let _ = A {
             kind: Some(a::Kind::B(Box::new(B {
                 a: Some(Box::new(A {
-                    kind: Some(a::Kind::C(C {}))
-                }))
-            })))
+                    kind: Some(a::Kind::C(C {})),
+                })),
+            }))),
         };
     }
 }

--- a/tests/src/message_encoding.rs
+++ b/tests/src/message_encoding.rs
@@ -5,9 +5,9 @@ use check_serialize_equivalent;
 
 #[derive(Clone, PartialEq, Message)]
 pub struct RepeatedFloats {
-    #[prost(float, tag="11")]
+    #[prost(float, tag = "11")]
     pub single_float: f32,
-    #[prost(float, repeated, packed="true", tag="41")]
+    #[prost(float, repeated, packed = "true", tag = "41")]
     pub repeated_float: Vec<f32>,
 }
 
@@ -18,7 +18,7 @@ fn check_repeated_floats() {
         repeated_float: vec![
             0.1,
             340282300000000000000000000000000000000.0,
-            0.000000000000000000000000000000000000011754944
+            0.000000000000000000000000000000000000011754944,
         ],
     });
 }
@@ -31,161 +31,161 @@ fn check_scalar_types() {
 /// A protobuf message which contains all scalar types.
 #[derive(Clone, PartialEq, Message)]
 pub struct ScalarTypes {
-    #[prost(int32, tag="001")]
+    #[prost(int32, tag = "001")]
     pub int32: i32,
-    #[prost(int64, tag="002")]
+    #[prost(int64, tag = "002")]
     pub int64: i64,
-    #[prost(uint32, tag="003")]
+    #[prost(uint32, tag = "003")]
     pub uint32: u32,
-    #[prost(uint64, tag="004")]
+    #[prost(uint64, tag = "004")]
     pub uint64: u64,
-    #[prost(sint32, tag="005")]
+    #[prost(sint32, tag = "005")]
     pub sint32: i32,
-    #[prost(sint64, tag="006")]
+    #[prost(sint64, tag = "006")]
     pub sint64: i64,
-    #[prost(fixed32, tag="007")]
+    #[prost(fixed32, tag = "007")]
     pub fixed32: u32,
-    #[prost(fixed64, tag="008")]
+    #[prost(fixed64, tag = "008")]
     pub fixed64: u64,
-    #[prost(sfixed32, tag="009")]
+    #[prost(sfixed32, tag = "009")]
     pub sfixed32: i32,
-    #[prost(sfixed64, tag="010")]
+    #[prost(sfixed64, tag = "010")]
     pub sfixed64: i64,
-    #[prost(float, tag="011")]
+    #[prost(float, tag = "011")]
     pub float: f32,
-    #[prost(double, tag="012")]
+    #[prost(double, tag = "012")]
     pub double: f64,
-    #[prost(bool, tag="013")]
+    #[prost(bool, tag = "013")]
     pub _bool: bool,
-    #[prost(string, tag="014")]
+    #[prost(string, tag = "014")]
     pub string: String,
-    #[prost(bytes, tag="015")]
+    #[prost(bytes, tag = "015")]
     pub bytes: Vec<u8>,
 
-    #[prost(int32, required, tag="101")]
+    #[prost(int32, required, tag = "101")]
     pub required_int32: i32,
-    #[prost(int64, required, tag="102")]
+    #[prost(int64, required, tag = "102")]
     pub required_int64: i64,
-    #[prost(uint32, required, tag="103")]
+    #[prost(uint32, required, tag = "103")]
     pub required_uint32: u32,
-    #[prost(uint64, required, tag="104")]
+    #[prost(uint64, required, tag = "104")]
     pub required_uint64: u64,
-    #[prost(sint32, required, tag="105")]
+    #[prost(sint32, required, tag = "105")]
     pub required_sint32: i32,
-    #[prost(sint64, required, tag="106")]
+    #[prost(sint64, required, tag = "106")]
     pub required_sint64: i64,
-    #[prost(fixed32, required, tag="107")]
+    #[prost(fixed32, required, tag = "107")]
     pub required_fixed32: u32,
-    #[prost(fixed64, required, tag="108")]
+    #[prost(fixed64, required, tag = "108")]
     pub required_fixed64: u64,
-    #[prost(sfixed32, required, tag="109")]
+    #[prost(sfixed32, required, tag = "109")]
     pub required_sfixed32: i32,
-    #[prost(sfixed64, required, tag="110")]
+    #[prost(sfixed64, required, tag = "110")]
     pub required_sfixed64: i64,
-    #[prost(float, required, tag="111")]
+    #[prost(float, required, tag = "111")]
     pub required_float: f32,
-    #[prost(double, required, tag="112")]
+    #[prost(double, required, tag = "112")]
     pub required_double: f64,
-    #[prost(bool, required, tag="113")]
+    #[prost(bool, required, tag = "113")]
     pub required_bool: bool,
-    #[prost(string, required, tag="114")]
+    #[prost(string, required, tag = "114")]
     pub required_string: String,
-    #[prost(bytes, required, tag="115")]
+    #[prost(bytes, required, tag = "115")]
     pub required_bytes: Vec<u8>,
 
-    #[prost(int32, optional, tag="201")]
+    #[prost(int32, optional, tag = "201")]
     pub optional_int32: Option<i32>,
-    #[prost(int64, optional, tag="202")]
+    #[prost(int64, optional, tag = "202")]
     pub optional_int64: Option<i64>,
-    #[prost(uint32, optional, tag="203")]
+    #[prost(uint32, optional, tag = "203")]
     pub optional_uint32: Option<u32>,
-    #[prost(uint64, optional, tag="204")]
+    #[prost(uint64, optional, tag = "204")]
     pub optional_uint64: Option<u64>,
-    #[prost(sint32, optional, tag="205")]
+    #[prost(sint32, optional, tag = "205")]
     pub optional_sint32: Option<i32>,
-    #[prost(sint64, optional, tag="206")]
+    #[prost(sint64, optional, tag = "206")]
     pub optional_sint64: Option<i64>,
 
-    #[prost(fixed32, optional, tag="207")]
+    #[prost(fixed32, optional, tag = "207")]
     pub optional_fixed32: Option<u32>,
-    #[prost(fixed64, optional, tag="208")]
+    #[prost(fixed64, optional, tag = "208")]
     pub optional_fixed64: Option<u64>,
-    #[prost(sfixed32, optional, tag="209")]
+    #[prost(sfixed32, optional, tag = "209")]
     pub optional_sfixed32: Option<i32>,
-    #[prost(sfixed64, optional, tag="210")]
+    #[prost(sfixed64, optional, tag = "210")]
     pub optional_sfixed64: Option<i64>,
-    #[prost(float, optional, tag="211")]
+    #[prost(float, optional, tag = "211")]
     pub optional_float: Option<f32>,
-    #[prost(double, optional, tag="212")]
+    #[prost(double, optional, tag = "212")]
     pub optional_double: Option<f64>,
-    #[prost(bool, optional, tag="213")]
+    #[prost(bool, optional, tag = "213")]
     pub optional_bool: Option<bool>,
-    #[prost(string, optional, tag="214")]
+    #[prost(string, optional, tag = "214")]
     pub optional_string: Option<String>,
-    #[prost(bytes, optional, tag="215")]
+    #[prost(bytes, optional, tag = "215")]
     pub optional_bytes: Option<Vec<u8>>,
 
-    #[prost(int32, repeated, packed="false", tag="301")]
+    #[prost(int32, repeated, packed = "false", tag = "301")]
     pub repeated_int32: Vec<i32>,
-    #[prost(int64, repeated, packed="false", tag="302")]
+    #[prost(int64, repeated, packed = "false", tag = "302")]
     pub repeated_int64: Vec<i64>,
-    #[prost(uint32, repeated, packed="false", tag="303")]
+    #[prost(uint32, repeated, packed = "false", tag = "303")]
     pub repeated_uint32: Vec<u32>,
-    #[prost(uint64, repeated, packed="false", tag="304")]
+    #[prost(uint64, repeated, packed = "false", tag = "304")]
     pub repeated_uint64: Vec<u64>,
-    #[prost(sint32, repeated, packed="false", tag="305")]
+    #[prost(sint32, repeated, packed = "false", tag = "305")]
     pub repeated_sint32: Vec<i32>,
-    #[prost(sint64, repeated, packed="false", tag="306")]
+    #[prost(sint64, repeated, packed = "false", tag = "306")]
     pub repeated_sint64: Vec<i64>,
-    #[prost(fixed32, repeated, packed="false", tag="307")]
+    #[prost(fixed32, repeated, packed = "false", tag = "307")]
     pub repeated_fixed32: Vec<u32>,
-    #[prost(fixed64, repeated, packed="false", tag="308")]
+    #[prost(fixed64, repeated, packed = "false", tag = "308")]
     pub repeated_fixed64: Vec<u64>,
-    #[prost(sfixed32, repeated, packed="false", tag="309")]
+    #[prost(sfixed32, repeated, packed = "false", tag = "309")]
     pub repeated_sfixed32: Vec<i32>,
-    #[prost(sfixed64, repeated, packed="false", tag="310")]
+    #[prost(sfixed64, repeated, packed = "false", tag = "310")]
     pub repeated_sfixed64: Vec<i64>,
-    #[prost(float, repeated, packed="false", tag="311")]
+    #[prost(float, repeated, packed = "false", tag = "311")]
     pub repeated_float: Vec<f32>,
-    #[prost(double, repeated, packed="false", tag="312")]
+    #[prost(double, repeated, packed = "false", tag = "312")]
     pub repeated_double: Vec<f64>,
-    #[prost(bool, repeated, packed="false", tag="313")]
+    #[prost(bool, repeated, packed = "false", tag = "313")]
     pub repeated_bool: Vec<bool>,
-    #[prost(string, repeated, packed="false", tag="315")]
+    #[prost(string, repeated, packed = "false", tag = "315")]
     pub repeated_string: Vec<String>,
-    #[prost(bytes, repeated, packed="false", tag="316")]
+    #[prost(bytes, repeated, packed = "false", tag = "316")]
     pub repeated_bytes: Vec<Vec<u8>>,
 
-    #[prost(int32, repeated, tag="401")]
+    #[prost(int32, repeated, tag = "401")]
     pub packed_int32: Vec<i32>,
-    #[prost(int64, repeated, tag="402")]
+    #[prost(int64, repeated, tag = "402")]
     pub packed_int64: Vec<i64>,
-    #[prost(uint32, repeated, tag="403")]
+    #[prost(uint32, repeated, tag = "403")]
     pub packed_uint32: Vec<u32>,
-    #[prost(uint64, repeated, tag="404")]
+    #[prost(uint64, repeated, tag = "404")]
     pub packed_uint64: Vec<u64>,
-    #[prost(sint32, repeated, tag="405")]
+    #[prost(sint32, repeated, tag = "405")]
     pub packed_sint32: Vec<i32>,
-    #[prost(sint64, repeated, tag="406")]
+    #[prost(sint64, repeated, tag = "406")]
     pub packed_sint64: Vec<i64>,
-    #[prost(fixed32, repeated, tag="407")]
+    #[prost(fixed32, repeated, tag = "407")]
     pub packed_fixed32: Vec<u32>,
 
-    #[prost(fixed64, repeated, tag="408")]
+    #[prost(fixed64, repeated, tag = "408")]
     pub packed_fixed64: Vec<u64>,
-    #[prost(sfixed32, repeated, tag="409")]
+    #[prost(sfixed32, repeated, tag = "409")]
     pub packed_sfixed32: Vec<i32>,
-    #[prost(sfixed64, repeated, tag="410")]
+    #[prost(sfixed64, repeated, tag = "410")]
     pub packed_sfixed64: Vec<i64>,
-    #[prost(float, repeated, tag="411")]
+    #[prost(float, repeated, tag = "411")]
     pub packed_float: Vec<f32>,
-    #[prost(double, repeated, tag="412")]
+    #[prost(double, repeated, tag = "412")]
     pub packed_double: Vec<f64>,
-    #[prost(bool, repeated, tag="413")]
+    #[prost(bool, repeated, tag = "413")]
     pub packed_bool: Vec<bool>,
-    #[prost(string, repeated, tag="415")]
+    #[prost(string, repeated, tag = "415")]
     pub packed_string: Vec<String>,
-    #[prost(bytes, repeated, tag="416")]
+    #[prost(bytes, repeated, tag = "416")]
     pub packed_bytes: Vec<Vec<u8>>,
 }
 
@@ -204,14 +204,14 @@ pub struct TagsInferred {
     #[prost(float, repeated)]
     pub three: Vec<f32>,
 
-    #[prost(tag="9", string, required)]
+    #[prost(tag = "9", string, required)]
     pub skip_to_nine: String,
-    #[prost(enumeration="BasicEnumeration", default="ONE")]
+    #[prost(enumeration = "BasicEnumeration", default = "ONE")]
     pub ten: i32,
-    #[prost(map="string, string")]
+    #[prost(map = "string, string")]
     pub eleven: ::std::collections::HashMap<String, String>,
 
-    #[prost(tag="5", bytes)]
+    #[prost(tag = "5", bytes)]
     pub back_to_five: Vec<u8>,
     #[prost(message, required)]
     pub six: Basic,
@@ -219,45 +219,45 @@ pub struct TagsInferred {
 
 #[derive(Clone, PartialEq, Message)]
 pub struct TagsQualified {
-    #[prost(tag="1", bool)]
+    #[prost(tag = "1", bool)]
     pub one: bool,
-    #[prost(tag="2", int32, optional)]
+    #[prost(tag = "2", int32, optional)]
     pub two: Option<i32>,
-    #[prost(tag="3", float, repeated)]
+    #[prost(tag = "3", float, repeated)]
     pub three: Vec<f32>,
 
-    #[prost(tag="5", bytes)]
+    #[prost(tag = "5", bytes)]
     pub five: Vec<u8>,
-    #[prost(tag="6", message, required)]
+    #[prost(tag = "6", message, required)]
     pub six: Basic,
 
-    #[prost(tag="9", string, required)]
+    #[prost(tag = "9", string, required)]
     pub nine: String,
-    #[prost(tag="10", enumeration="BasicEnumeration", default="ONE")]
+    #[prost(tag = "10", enumeration = "BasicEnumeration", default = "ONE")]
     pub ten: i32,
-    #[prost(tag="11", map="string, string")]
+    #[prost(tag = "11", map = "string, string")]
     pub eleven: ::std::collections::HashMap<String, String>,
 }
 
 /// A prost message with default value.
 #[derive(Clone, PartialEq, Message)]
 pub struct DefaultValues {
-    #[prost(int32, tag="1", default="42")]
+    #[prost(int32, tag = "1", default = "42")]
     pub int32: i32,
 
-    #[prost(int32, optional, tag="2", default="88")]
+    #[prost(int32, optional, tag = "2", default = "88")]
     pub optional_int32: Option<i32>,
 
-    #[prost(string, tag="3", default="fourty two")]
+    #[prost(string, tag = "3", default = "fourty two")]
     pub string: String,
 
-    #[prost(enumeration="BasicEnumeration", tag="4", default="ONE")]
+    #[prost(enumeration = "BasicEnumeration", tag = "4", default = "ONE")]
     pub enumeration: i32,
 
-    #[prost(enumeration="BasicEnumeration", optional, tag="5", default="TWO")]
+    #[prost(enumeration = "BasicEnumeration", optional, tag = "5", default = "TWO")]
     pub optional_enumeration: Option<i32>,
 
-    #[prost(enumeration="BasicEnumeration", repeated, tag="6")]
+    #[prost(enumeration = "BasicEnumeration", repeated, tag = "6")]
     pub repeated_enumeration: Vec<i32>,
 }
 
@@ -284,59 +284,59 @@ pub enum BasicEnumeration {
 
 #[derive(Clone, PartialEq, Message)]
 pub struct Basic {
-    #[prost(int32, tag="1")]
+    #[prost(int32, tag = "1")]
     pub int32: i32,
 
-    #[prost(bool, repeated, packed="false", tag="2")]
+    #[prost(bool, repeated, packed = "false", tag = "2")]
     pub bools: Vec<bool>,
 
-    #[prost(string, tag="3")]
+    #[prost(string, tag = "3")]
     pub string: String,
 
-    #[prost(string, optional, tag="4")]
+    #[prost(string, optional, tag = "4")]
     pub optional_string: Option<String>,
 
-    #[prost(enumeration="BasicEnumeration", tag="5")]
+    #[prost(enumeration = "BasicEnumeration", tag = "5")]
     pub enumeration: i32,
 
-    #[prost(map="int32, enumeration(BasicEnumeration)", tag="6")]
+    #[prost(map = "int32, enumeration(BasicEnumeration)", tag = "6")]
     pub enumeration_map: ::std::collections::HashMap<i32, i32>,
 
-    #[prost(hash_map="string, string", tag="7")]
+    #[prost(hash_map = "string, string", tag = "7")]
     pub string_map: ::std::collections::HashMap<String, String>,
 
-    #[prost(btree_map="int32, enumeration(BasicEnumeration)", tag="10")]
+    #[prost(btree_map = "int32, enumeration(BasicEnumeration)", tag = "10")]
     pub enumeration_btree_map: ::std::collections::BTreeMap<i32, i32>,
 
-    #[prost(btree_map="string, string", tag="11")]
+    #[prost(btree_map = "string, string", tag = "11")]
     pub string_btree_map: ::std::collections::BTreeMap<String, String>,
 
-    #[prost(oneof="BasicOneof", tags="8, 9")]
+    #[prost(oneof = "BasicOneof", tags = "8, 9")]
     pub oneof: Option<BasicOneof>,
 }
 
 #[derive(Clone, PartialEq, Message)]
 pub struct Compound {
-    #[prost(message, optional, tag="1")]
+    #[prost(message, optional, tag = "1")]
     pub optional_message: Option<Basic>,
 
-    #[prost(message, required, tag="2")]
+    #[prost(message, required, tag = "2")]
     pub required_message: Basic,
 
-    #[prost(message, repeated, tag="3")]
+    #[prost(message, repeated, tag = "3")]
     pub repeated_message: Vec<Basic>,
 
-    #[prost(map="sint32, message", tag="4")]
+    #[prost(map = "sint32, message", tag = "4")]
     pub message_map: ::std::collections::HashMap<i32, Basic>,
 
-    #[prost(btree_map="sint32, message", tag="5")]
+    #[prost(btree_map = "sint32, message", tag = "5")]
     pub message_btree_map: ::std::collections::BTreeMap<i32, Basic>,
 }
 
 #[derive(Clone, PartialEq, Oneof)]
 pub enum BasicOneof {
-    #[prost(int32, tag="8")]
+    #[prost(int32, tag = "8")]
     Int(i32),
-    #[prost(string, tag="9")]
+    #[prost(string, tag = "9")]
     String(String),
 }

--- a/tests/src/unittest.rs
+++ b/tests/src/unittest.rs
@@ -11,7 +11,10 @@ fn extreme_default_values() {
     use std::{f32, f64};
     let pb = protobuf_unittest::TestExtremeDefaultValues::default();
 
-    assert_eq!(b"\0\x01\x07\x08\x0C\n\r\t\x0B\\\'\"\xFE", pb.escaped_bytes());
+    assert_eq!(
+        b"\0\x01\x07\x08\x0C\n\r\t\x0B\\\'\"\xFE",
+        pb.escaped_bytes()
+    );
 
     assert_eq!(0xFFFFFFFF, pb.large_uint32());
     assert_eq!(0xFFFFFFFFFFFFFFFF, pb.large_uint64());


### PR DESCRIPTION
This PR opdates `bytes` to `0.5`

It also removes a hack to the lifetimes that polonius landing make unnecessary and fixes some of the open clippy lints.