### PR TITLE
prost-amino-derive: upgrade dependencies

### DIFF
--- a/prost-amino-derive/Cargo.toml
+++ b/prost-amino-derive/Cargo.toml
@@ -15,8 +15,7 @@ proc_macro = true
 [dependencies]
 failure = { version = "0.1", default-features = false, features = ["std"] }
 itertools = "0.7"
-proc-macro2 = "0.4.4"
-quote = "0.6.3"
-syn = { version = "0.14.1", features = [ "extra-traits" ] }
-sha2 = "0.8"
-digest ="0.7"
+proc-macro2 = "1"
+quote = "1"
+syn = { version = "1", features = [ "extra-traits" ] }
+sha2 = "0.9"

--- a/prost-amino-derive/src/field/mod.rs
+++ b/prost-amino-derive/src/field/mod.rs
@@ -189,9 +189,9 @@ impl Label {
     /// Parses a string into a field label.
     /// If the string doesn't match a field label, `None` is returned.
     fn from_attr(attr: &Meta) -> Option<Label> {
-        if let Meta::Word(ref ident) = *attr {
+        if let Meta::Path(ref path) = *attr {
             for &label in Label::variants() {
-                if ident == label.as_str() {
+                if path.is_ident(label.as_str()) {
                     return Some(label);
                 }
             }
@@ -213,13 +213,13 @@ impl fmt::Display for Label {
 }
 
 /// Get the items belonging to the 'prost' list attribute, e.g. `#[prost(foo, bar="baz")]`.
-fn prost_attrs(attrs: Vec<Attribute>) -> Result<Vec<Meta>, Error> {
+pub(super) fn prost_attrs(attrs: Vec<Attribute>) -> Result<Vec<Meta>, Error> {
     Ok(attrs
         .iter()
-        .flat_map(Attribute::interpret_meta)
+        .flat_map(Attribute::parse_meta)
         .flat_map(|meta| match meta {
-            Meta::List(MetaList { ident, nested, .. }) => {
-                if ident == "prost_amino" {
+            Meta::List(MetaList { path, nested, .. }) => {
+                if path.is_ident("prost_amino") {
                     nested.into_iter().collect()
                 } else {
                     Vec::new()
@@ -230,7 +230,7 @@ fn prost_attrs(attrs: Vec<Attribute>) -> Result<Vec<Meta>, Error> {
         .flat_map(|attr| -> Result<_, _> {
             match attr {
                 NestedMeta::Meta(attr) => Ok(attr),
-                NestedMeta::Literal(lit) => bail!("invalid prost attribute: {:?}", lit),
+                NestedMeta::Lit(lit) => bail!("invalid prost attribute: {:?}", lit),
             }
         })
         .collect())
@@ -259,15 +259,15 @@ pub fn set_bool(b: &mut bool, message: &str) -> Result<(), Error> {
 /// Unpacks an attribute into a (key, boolean) pair, returning the boolean value.
 /// If the key doesn't match the attribute, `None` is returned.
 fn bool_attr(key: &str, attr: &Meta) -> Result<Option<bool>, Error> {
-    if attr.name() != key {
+    if !attr.path().is_ident(key) {
         return Ok(None);
     }
     match *attr {
-        Meta::Word(..) => Ok(Some(true)),
+        Meta::Path(..) => Ok(Some(true)),
         Meta::List(ref meta_list) => {
             // TODO(rustlang/rust#23121): slice pattern matching would make this much nicer.
             if meta_list.nested.len() == 1 {
-                if let NestedMeta::Literal(Lit::Bool(LitBool { value, .. })) = meta_list.nested[0] {
+                if let NestedMeta::Lit(Lit::Bool(LitBool { value, .. })) = meta_list.nested[0] {
                     return Ok(Some(value));
                 }
             }
@@ -291,23 +291,23 @@ fn bool_attr(key: &str, attr: &Meta) -> Result<Option<bool>, Error> {
 
 /// Checks if an attribute matches a word.
 fn word_attr(key: &str, attr: &Meta) -> bool {
-    if let Meta::Word(ref ident) = *attr {
-        ident == key
+    if let Meta::Path(ref path) = *attr {
+        path.is_ident(key)
     } else {
         false
     }
 }
 
-fn tag_attr(attr: &Meta) -> Result<Option<u32>, Error> {
-    if attr.name() != "tag" {
+pub(super) fn tag_attr(attr: &Meta) -> Result<Option<u32>, Error> {
+    if !attr.path().is_ident("tag") {
         return Ok(None);
     }
     match *attr {
         Meta::List(ref meta_list) => {
             // TODO(rustlang/rust#23121): slice pattern matching would make this much nicer.
             if meta_list.nested.len() == 1 {
-                if let NestedMeta::Literal(Lit::Int(ref lit)) = meta_list.nested[0] {
-                    return Ok(Some(lit.value() as u32));
+                if let NestedMeta::Lit(Lit::Int(ref lit)) = meta_list.nested[0] {
+                    return Ok(Some(lit.base10_parse()?));
                 }
             }
             bail!("invalid tag attribute: {:?}", attr);
@@ -318,7 +318,7 @@ fn tag_attr(attr: &Meta) -> Result<Option<u32>, Error> {
                 .parse::<u32>()
                 .map_err(Error::from)
                 .map(Option::Some),
-            Lit::Int(ref lit) => Ok(Some(lit.value() as u32)),
+            Lit::Int(ref lit) => Ok(Some(lit.base10_parse()?)),
             _ => bail!("invalid tag attribute: {:?}", attr),
         },
         _ => bail!("invalid tag attribute: {:?}", attr),
@@ -326,7 +326,7 @@ fn tag_attr(attr: &Meta) -> Result<Option<u32>, Error> {
 }
 
 fn amino_name_attr(attr: &Meta) -> Result<Option<String>, Error> {
-    if attr.name() != "amino_name" {
+    if !attr.path().is_ident("amino_name") {
         return Ok(None);
     }
     match *attr {
@@ -339,20 +339,20 @@ fn amino_name_attr(attr: &Meta) -> Result<Option<String>, Error> {
 }
 
 fn tags_attr(attr: &Meta) -> Result<Option<Vec<u32>>, Error> {
-    if attr.name() != "tags" {
+    if !attr.path().is_ident("tags") {
         return Ok(None);
     }
     match *attr {
         Meta::List(ref meta_list) => {
             let mut tags = Vec::with_capacity(meta_list.nested.len());
             for item in &meta_list.nested {
-                if let NestedMeta::Literal(Lit::Int(ref lit)) = *item {
-                    tags.push(lit.value() as u32);
+                if let NestedMeta::Lit(Lit::Int(ref lit)) = *item {
+                    tags.push(lit.base10_parse()?);
                 } else {
                     bail!("invalid tag attribute: {:?}", attr);
                 }
             }
-            return Ok(Some(tags));
+            Ok(Some(tags))
         }
         Meta::NameValue(MetaNameValue {
             lit: Lit::Str(ref lit),
@@ -362,7 +362,7 @@ fn tags_attr(attr: &Meta) -> Result<Option<Vec<u32>>, Error> {
             .split(',')
             .map(|s| s.trim().parse::<u32>().map_err(Error::from))
             .collect::<Result<Vec<u32>, _>>()
-            .map(|tags| Some(tags)),
+            .map(Some),
         _ => bail!("invalid tag attribute: {:?}", attr),
     }
 }

--- a/prost-amino-derive/src/field/oneof.rs
+++ b/prost-amino-derive/src/field/oneof.rs
@@ -17,7 +17,7 @@ impl Field {
         let mut unknown_attrs = Vec::new();
 
         for attr in attrs {
-            if attr.name() == "oneof" {
+            if attr.path().is_ident("oneof") {
                 let t = match *attr {
                     Meta::NameValue(MetaNameValue {
                         lit: Lit::Str(ref lit),
@@ -25,8 +25,12 @@ impl Field {
                     }) => parse_str::<Path>(&lit.value())?,
                     Meta::List(ref list) if list.nested.len() == 1 => {
                         // TODO(rustlang/rust#23121): slice pattern matching would make this much nicer.
-                        if let NestedMeta::Meta(Meta::Word(ref ident)) = list.nested[0] {
-                            Path::from(ident.clone())
+                        if let NestedMeta::Meta(Meta::Path(ref path)) = list.nested[0] {
+                            if let Some(ident) = path.get_ident() {
+                                Path::from(ident.clone())
+                            } else {
+                                bail!("invalid oneof attribute: item must be an identifier");
+                            }
                         } else {
                             bail!("invalid oneof attribute: item must be an identifier");
                         }
@@ -60,7 +64,7 @@ impl Field {
             None => bail!("oneof field is missing a tags attribute"),
         };
 
-        Ok(Some(Field { ty: ty, tags: tags }))
+        Ok(Some(Field { ty, tags }))
     }
 
     /// Returns a statement which encodes the oneof field.

--- a/prost-amino-derive/src/field/scalar.rs
+++ b/prost-amino-derive/src/field/scalar.rs
@@ -3,10 +3,8 @@ use std::fmt;
 use failure::Error;
 use proc_macro2::{Span, TokenStream};
 use quote;
-use syn::{
-    self, parse_str, FloatSuffix, Ident, IntSuffix, Lit, LitByteStr, Meta, MetaList, MetaNameValue,
-    NestedMeta, Path,
-};
+use std::convert::TryFrom;
+use syn::{parse_str, Ident, Lit, LitByteStr, Meta, MetaList, MetaNameValue, NestedMeta, Path};
 
 use field::{amino_name_attr, bool_attr, set_option, tag_attr, Label};
 
@@ -406,35 +404,35 @@ pub enum Ty {
 impl Ty {
     pub fn from_attr(attr: &Meta) -> Result<Option<Ty>, Error> {
         let ty = match *attr {
-            Meta::Word(ref name) if name == "float" => Ty::Float,
-            Meta::Word(ref name) if name == "double" => Ty::Double,
-            Meta::Word(ref name) if name == "int32" => Ty::Int32,
-            Meta::Word(ref name) if name == "int64" => Ty::Int64,
-            Meta::Word(ref name) if name == "uint32" => Ty::Uint32,
-            Meta::Word(ref name) if name == "uint64" => Ty::Uint64,
-            Meta::Word(ref name) if name == "sint32" => Ty::Sint32,
-            Meta::Word(ref name) if name == "sint64" => Ty::Sint64,
-            Meta::Word(ref name) if name == "fixed32" => Ty::Fixed32,
-            Meta::Word(ref name) if name == "fixed64" => Ty::Fixed64,
-            Meta::Word(ref name) if name == "sfixed32" => Ty::Sfixed32,
-            Meta::Word(ref name) if name == "sfixed64" => Ty::Sfixed64,
-            Meta::Word(ref name) if name == "bool" => Ty::Bool,
-            Meta::Word(ref name) if name == "string" => Ty::String,
-            Meta::Word(ref name) if name == "bytes" => Ty::Bytes,
+            Meta::Path(ref name) if name.is_ident("float") => Ty::Float,
+            Meta::Path(ref name) if name.is_ident("double") => Ty::Double,
+            Meta::Path(ref name) if name.is_ident("int32") => Ty::Int32,
+            Meta::Path(ref name) if name.is_ident("int64") => Ty::Int64,
+            Meta::Path(ref name) if name.is_ident("uint32") => Ty::Uint32,
+            Meta::Path(ref name) if name.is_ident("uint64") => Ty::Uint64,
+            Meta::Path(ref name) if name.is_ident("sint32") => Ty::Sint32,
+            Meta::Path(ref name) if name.is_ident("sint64") => Ty::Sint64,
+            Meta::Path(ref name) if name.is_ident("fixed32") => Ty::Fixed32,
+            Meta::Path(ref name) if name.is_ident("fixed64") => Ty::Fixed64,
+            Meta::Path(ref name) if name.is_ident("sfixed32") => Ty::Sfixed32,
+            Meta::Path(ref name) if name.is_ident("sfixed64") => Ty::Sfixed64,
+            Meta::Path(ref name) if name.is_ident("bool") => Ty::Bool,
+            Meta::Path(ref name) if name.is_ident("string") => Ty::String,
+            Meta::Path(ref name) if name.is_ident("bytes") => Ty::Bytes,
             Meta::NameValue(MetaNameValue {
-                ref ident,
+                ref path,
                 lit: Lit::Str(ref l),
                 ..
-            }) if ident == "enumeration" => Ty::Enumeration(parse_str::<Path>(&l.value())?),
+            }) if path.is_ident("enumeration") => Ty::Enumeration(parse_str::<Path>(&l.value())?),
             Meta::List(MetaList {
-                ref ident,
+                ref path,
                 ref nested,
                 ..
-            }) if ident == "enumeration" => {
+            }) if path.is_ident("enumeration") => {
                 // TODO(rustlang/rust#23121): slice pattern matching would make this much nicer.
                 if nested.len() == 1 {
-                    if let NestedMeta::Meta(Meta::Word(ref ident)) = nested[0] {
-                        Ty::Enumeration(Path::from(ident.clone()))
+                    if let NestedMeta::Meta(Meta::Path(ref path)) = nested[0] {
+                        Ty::Enumeration(path.clone())
                     } else {
                         bail!("invalid enumeration attribute: item must be an identifier");
                     }
@@ -595,8 +593,8 @@ pub enum DefaultValue {
 
 impl DefaultValue {
     pub fn from_attr(attr: &Meta) -> Result<Option<Lit>, Error> {
-        if attr.name() != "default" {
-            return Ok(None);
+        if !attr.path().is_ident("default") {
+            Ok(None)
         } else if let Meta::NameValue(ref name_value) = *attr {
             Ok(Some(name_value.lit.clone()))
         } else {
@@ -611,51 +609,35 @@ impl DefaultValue {
         let is_u32 = *ty == Ty::Uint32 || *ty == Ty::Fixed32;
         let is_u64 = *ty == Ty::Uint64 || *ty == Ty::Fixed64;
 
+        let empty_or_is = |expected, actual: &str| expected == actual || actual.is_empty();
+
         let default = match lit {
-            Lit::Int(ref lit)
-                if is_i32
-                    && (lit.suffix() == IntSuffix::I32 || lit.suffix() == IntSuffix::None) =>
-            {
-                DefaultValue::I32(lit.value() as _)
+            Lit::Int(ref lit) if is_i32 && empty_or_is("i32", lit.suffix()) => {
+                DefaultValue::I32(lit.base10_parse()?)
             }
-            Lit::Int(ref lit)
-                if is_i64
-                    && (lit.suffix() == IntSuffix::I64 || lit.suffix() == IntSuffix::None) =>
-            {
-                DefaultValue::I64(lit.value() as _)
+            Lit::Int(ref lit) if is_i64 && empty_or_is("i64", lit.suffix()) => {
+                DefaultValue::I64(lit.base10_parse()?)
             }
-            Lit::Int(ref lit)
-                if is_u32
-                    && (lit.suffix() == IntSuffix::U32 || lit.suffix() == IntSuffix::None) =>
-            {
-                DefaultValue::U32(lit.value() as _)
+            Lit::Int(ref lit) if is_u32 && empty_or_is("u32", lit.suffix()) => {
+                DefaultValue::U32(lit.base10_parse()?)
             }
-            Lit::Int(ref lit)
-                if is_u64
-                    && (lit.suffix() == IntSuffix::U64 || lit.suffix() == IntSuffix::None) =>
-            {
-                DefaultValue::U64(lit.value())
+            Lit::Int(ref lit) if is_u64 && empty_or_is("u64", lit.suffix()) => {
+                DefaultValue::U64(lit.base10_parse()?)
             }
 
-            Lit::Float(ref lit)
-                if *ty == Ty::Float
-                    && (lit.suffix() == FloatSuffix::F32 || lit.suffix() == FloatSuffix::None) =>
-            {
-                DefaultValue::F32(lit.value() as _)
+            Lit::Float(ref lit) if *ty == Ty::Float && empty_or_is("f32", lit.suffix()) => {
+                DefaultValue::F32(lit.base10_parse()?)
             }
-            Lit::Int(ref lit) if *ty == Ty::Float => DefaultValue::F32(lit.value() as _),
+            Lit::Int(ref lit) if *ty == Ty::Float => DefaultValue::F32(lit.base10_parse()?),
 
-            Lit::Float(ref lit)
-                if *ty == Ty::Double
-                    && (lit.suffix() == FloatSuffix::F64 || lit.suffix() == FloatSuffix::None) =>
-            {
-                DefaultValue::F64(lit.value())
+            Lit::Float(ref lit) if *ty == Ty::Double && empty_or_is("f64", lit.suffix()) => {
+                DefaultValue::F64(lit.base10_parse()?)
             }
-            Lit::Int(ref lit) if *ty == Ty::Double => DefaultValue::F64(lit.value() as _),
+            Lit::Int(ref lit) if *ty == Ty::Double => DefaultValue::F64(lit.base10_parse()?),
 
             Lit::Bool(ref lit) if *ty == Ty::Bool => DefaultValue::Bool(lit.value),
-            Lit::Str(ref lit) if *ty == Ty::String => DefaultValue::String(lit.value().clone()),
-            Lit::ByteStr(ref lit) if *ty == Ty::Bytes => DefaultValue::Bytes(lit.value().clone()),
+            Lit::Str(ref lit) if *ty == Ty::String => DefaultValue::String(lit.value()),
+            Lit::ByteStr(ref lit) if *ty == Ty::Bytes => DefaultValue::Bytes(lit.value()),
 
             Lit::Str(ref lit) => {
                 let value = lit.value();
@@ -671,16 +653,16 @@ impl DefaultValue {
                     match value {
                         "inf" => {
                             return Ok(DefaultValue::Path(parse_str::<Path>(
-                                "::std::f32::INFINITY",
-                            )?))
+                                "::core::f32::INFINITY",
+                            )?));
                         }
                         "-inf" => {
                             return Ok(DefaultValue::Path(parse_str::<Path>(
-                                "::std::f32::NEG_INFINITY",
-                            )?))
+                                "::core::f32::NEG_INFINITY",
+                            )?));
                         }
                         "nan" => {
-                            return Ok(DefaultValue::Path(parse_str::<Path>("::std::f32::NAN")?))
+                            return Ok(DefaultValue::Path(parse_str::<Path>("::core::f32::NAN")?));
                         }
                         _ => (),
                     }
@@ -689,67 +671,55 @@ impl DefaultValue {
                     match value {
                         "inf" => {
                             return Ok(DefaultValue::Path(parse_str::<Path>(
-                                "::std::f64::INFINITY",
-                            )?))
+                                "::core::f64::INFINITY",
+                            )?));
                         }
                         "-inf" => {
                             return Ok(DefaultValue::Path(parse_str::<Path>(
-                                "::std::f64::NEG_INFINITY",
-                            )?))
+                                "::core::f64::NEG_INFINITY",
+                            )?));
                         }
                         "nan" => {
-                            return Ok(DefaultValue::Path(parse_str::<Path>("::std::f64::NAN")?))
+                            return Ok(DefaultValue::Path(parse_str::<Path>("::core::f64::NAN")?));
                         }
                         _ => (),
                     }
                 }
 
                 // Rust doesn't have a negative literals, so they have to be parsed specially.
-                if value.chars().next() == Some('-') {
+                if value.starts_with('-') {
                     if let Ok(lit) = syn::parse_str::<Lit>(&value[1..]) {
                         match lit {
-                            Lit::Int(ref lit)
-                                if is_i32
-                                    && (lit.suffix() == IntSuffix::I32
-                                        || lit.suffix() == IntSuffix::None) =>
-                            {
-                                return Ok(DefaultValue::I32((!lit.value() + 1) as i32));
+                            Lit::Int(ref lit) if is_i32 && empty_or_is("i32", lit.suffix()) => {
+                                // Initially parse into an i64, so that i32::MIN does not overflow.
+                                let value: i64 = -lit.base10_parse()?;
+                                return Ok(i32::try_from(value).map(DefaultValue::I32)?);
                             }
 
-                            Lit::Int(ref lit)
-                                if is_i64
-                                    && (lit.suffix() == IntSuffix::I64
-                                        || lit.suffix() == IntSuffix::None) =>
-                            {
-                                return Ok(DefaultValue::I64((!lit.value() + 1) as i64));
+                            Lit::Int(ref lit) if is_i64 && empty_or_is("i64", lit.suffix()) => {
+                                // Initially parse into an i128, so that i64::MIN does not overflow.
+                                let value: i128 = -lit.base10_parse()?;
+                                return Ok(i64::try_from(value).map(DefaultValue::I64)?);
                             }
 
                             Lit::Float(ref lit)
-                                if *ty == Ty::Float
-                                    && (lit.suffix() == FloatSuffix::F32
-                                        || lit.suffix() == FloatSuffix::None) =>
+                                if *ty == Ty::Float && empty_or_is("f32", lit.suffix()) =>
                             {
-                                return Ok(DefaultValue::F32(-lit.value() as f32));
+                                return Ok(DefaultValue::F32(-lit.base10_parse()?));
                             }
 
                             Lit::Float(ref lit)
-                                if *ty == Ty::Double
-                                    && (lit.suffix() == FloatSuffix::F64
-                                        || lit.suffix() == FloatSuffix::None) =>
+                                if *ty == Ty::Double && empty_or_is("f64", lit.suffix()) =>
                             {
-                                return Ok(DefaultValue::F64(-lit.value()));
+                                return Ok(DefaultValue::F64(-lit.base10_parse()?));
                             }
 
-                            Lit::Int(ref lit)
-                                if *ty == Ty::Float && lit.suffix() == IntSuffix::None =>
-                            {
-                                return Ok(DefaultValue::F32(-(lit.value() as f32)));
+                            Lit::Int(ref lit) if *ty == Ty::Float && lit.suffix().is_empty() => {
+                                return Ok(DefaultValue::F32(-lit.base10_parse()?));
                             }
 
-                            Lit::Int(ref lit)
-                                if *ty == Ty::Double && lit.suffix() == IntSuffix::None =>
-                            {
-                                return Ok(DefaultValue::F64(-(lit.value() as f64)));
+                            Lit::Int(ref lit) if *ty == Ty::Double && lit.suffix().is_empty() => {
+                                return Ok(DefaultValue::F64(-lit.base10_parse()?));
                             }
 
                             _ => (),

--- a/prost-amino-derive/src/lib.rs
+++ b/prost-amino-derive/src/lib.rs
@@ -34,7 +34,7 @@ fn try_message(input: TokenStream) -> Result<TokenStream, Error> {
     let top_level_attrs: Vec<syn::Attribute> = input.attrs;
     let amino_name_attrs: Vec<syn::Attribute> = top_level_attrs
         .into_iter()
-        .filter(|a| a.path.segments.first().unwrap().value().ident == "amino_name")
+        .filter(|a| a.path.is_ident("amino_name"))
         .collect();
     if amino_name_attrs.len() > 1 {
         bail!("got more than one registered amino_name");
@@ -44,7 +44,7 @@ fn try_message(input: TokenStream) -> Result<TokenStream, Error> {
     let amino_name: Option<String> = {
         match amino_name_attrs.first() {
             Some(att) => {
-                let tts = att.tts.clone().into_iter().collect::<Vec<_>>();
+                let tts = att.tokens.clone().into_iter().collect::<Vec<_>>();
                 // for example:
                 //                [
                 //                    Punct {
@@ -582,8 +582,8 @@ pub fn oneof(input: TokenStream) -> TokenStream {
 
 fn compute_disfix(identity: &str) -> (Vec<u8>, Vec<u8>) {
     let mut sh = Sha256::default();
-    sh.input(identity.as_bytes());
-    let output = sh.result();
+    sh.update(identity.as_bytes());
+    let output = sh.finalize();
 
     let disamb_bytes = output
         .iter()
@@ -606,10 +606,6 @@ fn compute_disfix(identity: &str) -> (Vec<u8>, Vec<u8>) {
 #[cfg(test)]
 mod tests {
     use super::*;
-
-    use std::fmt;
-
-    use std::error;
 
     #[test]
     fn compare_to_go_amino() {


### PR DESCRIPTION
- Removes the (unused) `digest` v0.7 dependency
- Bumps the proc macro crates to v1.x:
  - `proc-macro2` v1
  - `quote` v1
  - `syn` v1
- Bumps `sha2` dependency to v0.9

Proc macro updates were done largely by copying and pasting the upstream
code from `prost-derive` and adjusting or adding back
`prost-amino`-related tweaks.